### PR TITLE
Added package/install dep. info for Ubuntu 20.04 + Port school console for linked esxi images on netzint page

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -25,6 +25,11 @@ Install sphinx, e.g. under Ubuntu 16.04, do
 
    ~$  sudo aptitude -R install git python3-sphinx texlive texlive-latex-extra texlive-lang-german
 
+for Ubuntu 20.04, do
+
+.. code:: bash
+  ~$ sudo apt install git python3-sphinx python3-stemmer python3-sphinx-rtd-them texlive texlive-latex-extra texlive-lang-german
+
 Make a local copy of your documentation using
 
 .. code:: bash

--- a/source/getting-started/setup.rst
+++ b/source/getting-started/setup.rst
@@ -76,7 +76,7 @@ Netzwerkmaske ``255.255.0.0``, dem Gateway ``10.0.0.254`` und dem DNS
 ``10.0.0.1``.
 
 Öffne auf dem Admin-PC mit einem Webbrowser die URL
-``http://10.0.0.1``. Melde dich hier einmalig mit dem Benutzer
+``http://10.0.0.1:8000``. Melde dich hier einmalig mit dem Benutzer
 `root` und dem Passwort `Muster!` an.
     
 .. figure:: media/root-login.png


### PR DESCRIPTION
Added install info for collob working/forking for ubuntu 20.04
+
Using linked ESXi images on netzint page --> school console is only reachable on port 8000
