### PR TITLE
anregungen

### DIFF
--- a/source/index.rst
+++ b/source/index.rst
@@ -7,10 +7,10 @@ Herzlich Willkommen zur Dokumentation von linuxmuster.net v7!
 
 Diese beschreibt alle wichtigen Schritte ...
 
-  | ... von der Installation.
-  | ... der Einrichtung von Windows- und Linux-Rechnern als Clients.
-  | ... der Systemadministration mit.
-  | ... der Verwaltung von Nutzern.
+  | ... von der Installation,
+  | ... der Einrichtung von Windows- und Linux-Rechnern als Clients,
+  | ... der Systemadministration,
+  | ... der Verwaltung von Nutzern,
   | ... bis hin zu individuellen Anpassungen.
 
 Wie es bei einem Projekt ist, dessen Entwicklungsgeschichte mittlerweile auf das Jahr 1999 zurückblickt, ist dein Einstieg in die Beschreibung unseres Systems sicherlich verschieden gelagert.


### PR DESCRIPTION
Warum nicht die Hinweise auf "Was ist linuxmuster.net?" auch verlinken? Auch wenn es das links in der Menüleiste gibt, würde ich vermuten, dass man doch direkt darauf klicken will.
Ebenso dann warum nicht diekt verlinken wenn "Was ist neu in 7.0?" erwähnt wird.

Die Einrückung mit den "|" finde ich etwas seltsam. Ich kenne diese Syntax gar nicht... Aber gut.