### PR TITLE
section about removing unneeded ip in noproxy and notes in differences between courses and projects

### DIFF
--- a/source/classroom/webui-basics/index.rst
+++ b/source/classroom/webui-basics/index.rst
@@ -262,12 +262,17 @@ dazugehörigen Schüler.
 Drucker
 -------
 
-Hier werden alle Drucker aufgelistet. Durch Anklicken werden weitere Informationen angezeigt.
+Hier werden alle Drucker aufgelistet. Durch Anklicken werden weitere Informationen angezeigt. Ein Auswählen ist nur erforderlich, wenn man den Drucker auch außerhalb des zugehörigen Raumes nutzen möchte.
 
 Projekte
 --------
 
-Hier werden alle Projekte aufgelistet.
+Hier werden alle Projekte aufgelistet. 
+Projekte unterscheiden sich von Kursen: 
+- Mehrere Lehrer können in eine Projektgruppe aufgenommen werden. 
+- Projekte verfügen über eigene Tauschverzeichnisse
+- Projekte können wiederverwendet werden.
+- Unterrichtssteuerung (Passwörter ändern, Internet sprerren, etc.) sind nicht möglich
 
 **Projekt anlegen**: Über
 

--- a/source/classroom/webui-basics/index.rst
+++ b/source/classroom/webui-basics/index.rst
@@ -267,12 +267,12 @@ Hier werden alle Drucker aufgelistet. Durch Anklicken werden weitere Information
 Projekte
 --------
 
-Hier werden alle Projekte aufgelistet. 
-Projekte unterscheiden sich von Kursen: 
-- Mehrere Lehrer können in eine Projektgruppe aufgenommen werden. 
-- Projekte verfügen über eigene Tauschverzeichnisse
-- Projekte können wiederverwendet werden.
-- Unterrichtssteuerung (Passwörter ändern, Internet sprerren, etc.) sind nicht möglich
+Hier werden alle Projekte aufgelistet. Projekte unterscheiden sich von Kursen: 
+
+* Mehrere Lehrer können in eine Projektgruppe aufgenommen werden. 
+* Projekte verfügen über eigene Tauschverzeichnisse
+* Projekte können wiederverwendet werden.
+* Unterrichtssteuerung (Passwörter ändern, Internet sprerren, etc.) ist nicht möglich
 
 **Projekt anlegen**: Über
 

--- a/source/systemadministration/network/default-access-rules.rst
+++ b/source/systemadministration/network/default-access-rules.rst
@@ -50,3 +50,9 @@ z.B. für einen Admin-PC oder für einen Masterclient verwendet werden.
    :align: center
    :alt: Edit the alias NoProxy
 
+Entfernen nicht benötigter IP
+=============================
+
+Während der Installation wurde das "NoProxy"-Alias automatisch mit den IP-Adressen ``10.0.0.1 - 10.0.0.10`` bzw. bei ``do-it-like-babo`` mit den IP-Adressen ``10.16.1.1 - 10.16.1.3`` und ``10.16.0.1 - 10.16.0.10`` angelegt. Normalerweise werden nicht alle für den Server, die Dockerhosts und evtl. Admin-PC benötigt.
+
+Als letzter Schritt vor dem Installationsende empfiehlt es sich, alle nicht dauerhaft benötigten IP-Adressen aus dem "NoProxy"-Alias zu entfernen. Hintergrund: Der Internetzugriff wird grundsätzlich über den Proxy geregelt. Gibt es unbenutzte IP-Adressen im "NoProxy"-Alias könnten diese unbefugt verwendet werden, um permanenten und ungefilterten Internetzugang zu erlangen.

--- a/source/systemadministration/network/default-access-rules.rst
+++ b/source/systemadministration/network/default-access-rules.rst
@@ -3,7 +3,8 @@
 ============================
 
 .. sectionauthor:: `@Thomas <https://ask.linuxmuster.net/u/Thomas>`_,
-		   `@Tobias <https://ask.linuxmuster.net/u/Tobias>`_
+		   `@Tobias <https://ask.linuxmuster.net/u/Tobias>`_,
+		   `@michael_kohls <https://ask.linuxmuster.net/u/michael_kohls>`_
 
 
 Zugriff über einen Proxy


### PR DESCRIPTION
Added a section about removing unneeded ip addresses from the noproxy alias. Unused ip can be used for unauthorized internet access.