### PR TITLE
v71: fixed docs according to thomas commments

### DIFF
--- a/source/about/release-info.rst
+++ b/source/about/release-info.rst
@@ -1,8 +1,4 @@
-.. Installationsleitfaden documentation master file, created by
-   sphinx-quickstart on Sat Nov  7 15:29:20 2015.
-   You can adapt this file completely to your liking, but it should at least
-   contain the root `toctree` directive.
-   
+
 Release-Informationen und Fehlerkorrekturen
 ===========================================
 

--- a/source/installation/install-from-scratch/buildserver.rst
+++ b/source/installation/install-from-scratch/buildserver.rst
@@ -80,7 +80,7 @@ Richte nun auf der 2. HDD ein LVM ein.
 
 .. figure:: media/lmn71-additional/custom-storage-layout-create-partition-table-lvm-hdb-5.png
 
-Wähle den Eintrag ``datenträgergruppe (LVM) anlegen`` aus.  
+Wähle den Eintrag ``Datenträgergruppe (LVM) anlegen`` aus.  
 
 Hier gibst du einen eigenen Namen für die LVM Volume Group an (z.B. vg_server oder vg0).
 
@@ -120,6 +120,11 @@ Wenn die Installation abgeschlossen und der Server neu gestartet ist, meldest du
    
 LVM - Besonderheiten
 --------------------
+
+.. hint::
+
+   Nutzt du später das Skript lmn71-appliance, um den Server vorzubereiten, dann musst du nur einen Server mit 2 HDDs haben und Ubuntu 18.04 auf der ersten HDD installieren. Die zweite HDD bleibt frei. Alles weitere wird dann später vom Skript lmn71-appliance erledigt.
+
 
 Hast du zuvor für die 2. HDD ein LVM eingerichtet, dann sind zur Vorbereitung noch nachstehende Schritte auszuführen:
 

--- a/source/installation/network/preliminarysettings/index.rst
+++ b/source/installation/network/preliminarysettings/index.rst
@@ -32,11 +32,6 @@ Das Skript lmn71-appliance installiert für dich das Paket linuxmuster-prepare m
 * Starte das Skript als Benutzer ``root`` mit: ``./lmn71-appliance -p server -u -l /dev/sdb``. Hierbei wird auf dem angegebenen Device/ der HDD ein LVM eingerichtet.
 * Für weitere Hinweise zum linuxmuster-prepare Skript siehe: https://github.com/linuxmuster/linuxmuster-prepare
 
-.. hint:: 
-
-   Falls Du dich für das Netz der linuxmuster.net V6.2 entschieden hast, führst du statt 
-   ``./lmn71-appliance -p server -u -l /dev/sdb`` Folgendes aus: ``./lmn71-appliance -p server -u -l /dev/sdb -n 10.16.1.1/12 -f 10.16.1.254``
-
 Im Anschluss kann das Setup ausgeführt werden, das dann den Netzbereich ausliest und für die weitere Einrichtung verwendet.
 
 Hinweise zum Skript
@@ -206,7 +201,7 @@ Mithilfe eines Ping-Test wird zuerst geprüft, ob der Server das Gateway erreich
 
 .. code::
 
-   ping 10.16.1.254
+   ping 10.0.0.254
 
 Ist dies erfolgreich, muss die Appliance mit dem Skript ``lmn71-appliance`` für das Setup vorbereitet werden. Netzwerkadressen und Domänenname werden damit gesetzt. 
 
@@ -235,7 +230,7 @@ Das alles kann **in einem Schritt** erfolgen:
 
    ./lmn71-appliance -s -u -d schule.lan -n 192.168.0.1/16 -f 192.168.0.10
 
-Minimaler Aufruf, wenn die Standard-Netzwerkeinstellungen (10.0.0.0/12) verwendet werden sollen:
+Minimaler Aufruf, wenn die Standard-Netzwerkeinstellungen (10.0.0.0/16) verwendet werden sollen:
 
 .. code::
 

--- a/source/installation/prerequisites.rst
+++ b/source/installation/prerequisites.rst
@@ -1,4 +1,3 @@
-.. include:: /guided-inst.subst
 
 .. _prerequisites-label:
 
@@ -86,40 +85,21 @@ IP-Bereiche
 Die linuxmuster.net-Lösung kann mit unterschiedlichen IP-Bereichen arbeiten. Standardmäßig wird das interne Netz aus dem privaten IPv4-Bereich 10.0.x.x mit der
 16-Bit Netzmaske 255.255.0.0 (/16) eingerichtet.
 
-Jedoch kann man sowohl die bisher in früheren Versionen von linuxmuster.net verwendeten Netze (10.16.0.0/12 oder 10.32.0.0/12 usw.) weiterverwenden, oder auch komplett andere private Adressbereiche realisieren.
-
-Jede Zeile der folgenden Tabelle stellt eine Möglichkeit dar.
-
-================== ================ ===========
-Beginn IP-Bereich  Ende IP-Bereich  Server-IP
-================== ================ ===========
-10.0.0.0           10.0.255.255     10.0.0.1
-10.16.0.0          10.31.255.255    10.16.1.1
-10.32.0.0          10.47.255.255    10.32.1.1
-================== ================ ===========
-
-Bei der Neuinstallation entscheidest du dich für einen der Bereiche.
+Andere private Adressbereiche sid prinzipiell möglich, müssen aber händisch vorbereitet werden. :ref:`modify-net-label`
 
 Standard IP-Adressen
 --------------------
 
 Einige IP-Adressen sind standardmäßig für spezielle Server/Dienste vorgesehen.
 
-========== =========== ============
-Server     IP-Bereich  IP-Bereich
-           10.0.0.0/16 10.16.0.0/12
-========== =========== ============
-OPNsense®  10.0.0.254  10.16.1.254
-Server     10.0.0.1    10.16.1.1
-XOA (*)    10.0.0.4    10.16.1.4
-Admin-PC   10.0.0.10   10.16.0.10
-========== =========== ============
-
-.. hint::
-
-   (*) Die XenOrchestra-Appliance (XOA) wird nur benötigt, wenn eine Virtualisierung mit XCP-ng erfolgen soll. Mithilfe von XenOrchestra kann die Virtualisierungsumgebung XCP-ng web-basiert verwaltet werden und es können hierüber auch sog. Enterprise-Funktionen wie z.B. Backup, Replikation etc. konfiguriert werden.
-
-
+========== ===========
+Server     IP-Bereich 
+           10.0.0.0/16 
+========== ===========
+OPNsense®  10.0.0.254 
+Server     10.0.0.1   
+Admin-PC   10.0.0.10  
+========== =========== 
 
 Netz-Grundstruktur
 ------------------

--- a/source/setup/setup.rst
+++ b/source/setup/setup.rst
@@ -28,7 +28,7 @@ Wichtige Hinweise
 
 * Nach Abschluss dieses Setups sind die Domäne und andere Details des Netzwerks permanent festgelegt und nur durch Neuinstallation änderbar. Es ist daher wichtig, zu diesem Zeitpunkt ein **Snapshot/Backup von Server und Firewall** anzufertigen. Sollte es beim Setup Fehler geben, oder Einstellungen nochmals geändert werden müssen, sind die virtuellen Maschinen auf den Stand des Snapshots zurückzusetzen und das Setup muss erneut aufgerufen werden.
 * Beim Domänennamen ist zu beachten, dass der **erste** Teil der Domäne nicht länger als 15 Zeichen sein darf! Dies ergibt sich aus den Samba/AD-Vorgaben. Im Beispiel ``server.linuxmuster.lan`` ist ``server`` der Rechnername und ``linuxmuster.lan`` die Domäne. Die Domäne ``linuxmuster`` darf nicht länger als **15 Zeichen** sein.
-* Will man eine Domäne nutzen, die auch extern auflösbar ist, sollte zusätzlich eine Subdomäne verwendet werden. Zum Beispiel``linuxmuster.meineschule.de`` statt ``meineschule.de``. Der erste Part ``linuxmuster`` wird in diesem Beispiel dann als SAMBA-Domäne verwendet. Der voll Name(FQHN) des Servers ist dann ``server.linuxmuster.meineschule.de``.
+* Will man eine Domäne nutzen, die auch extern auflösbar ist, sollte zusätzlich eine Subdomäne verwendet werden. Zum Beispiel``linuxmuster.meineschule.de`` statt ``meineschule.de``. Der erste Part ``linuxmuster`` wird in diesem Beispiel dann als SAMBA-Domäne verwendet. Der volle Name(FQDN) des Servers ist dann ``server.linuxmuster.meineschule.de``.
 * Alle Hosts die im Setup konfiguriert werden, müssen bereits laufen (OPNsense und Server). Diese müssen sich im internen LAN gegenseitig erreichen.
 * v6.x Systeme, die mit Hilfe der Migration auf linuxmuster.net 7.1 migriert werden, können eine neue (oder die alte) Domäne konfigurieren.
 
@@ -36,10 +36,9 @@ Anpassung des Netzbereichs
 ==========================
 
 Die Standardkonfiguration, sieht vor, dass das Schulnetz die lokale Domäne ``linuxmuster.lan`` bekommt und Geräte im Netzbereich ``10.0.0.0/16``
-stehen. Wenn ein anderer Netzbereich (z.B. der Netzbereich ``10.16.0.0/12``) verwendet werden soll, *muss* an dieser Stelle eine Anpassung vorgenommen werden.
+sind. Wenn ein anderer Netzbereich verwendet werden soll, *muss* an dieser Stelle eine Anpassung vorgenommen werden.
 
-v6.x Systeme, die mit Hilfe der Migration auf linuxmuster.net 7.1 migriert werden, sollten den bisherigen Netzbereich behalten. Für die Beibehaltung
-des bisherigen Standards der v6.2 mit einem ``10.16.0.0./12`` Netz gibt es den Begriff ``do-it-like-babo``.
+v6.x Systeme, die mit Hilfe der Migration auf linuxmuster.net 7.1 migriert werden, sollten den bisherigen Netzbereich behalten.
 
 .. hint::
 


### PR DESCRIPTION
IPs:
    10.0.0.0/16 ist Standard, der von uns ausgeliefert wird (10.16.1.0 ist kein Standard, also weglassen). -> fixed
    Als Beispiele würde ich noch 192.168.0.0 & 172.16.0.0 aufführen, um zu zeigen, dass man hier alle Freiheiten hat. -> still to be addressed

 LVM-Besonderheiten

    Das wird eigentlich alles von lmn71-appliance erledigt. Man benötigt nur einen Ubuntu-Server 18.04 mit 2 Platten, wobei die 2. Platte unkonfiguriert bleibt. -> fixed

 Das Skript lmn71-appliance

    Hinweis auf Netz von v6.2 bitte streichen. --> fixed




