### PR TITLE
Update install-nextcloud.rst

### DIFF
--- a/source/external-services/nextcloud/install-nextcloud.rst
+++ b/source/external-services/nextcloud/install-nextcloud.rst
@@ -138,7 +138,7 @@ Die Datei docker-compose.yml
 
   services:
     db2:
-      image: mariadb
+      image: mariadb:10.5
       command: --transaction-isolation=READ-COMMITTED --binlog-format=ROW
       restart: always
       volumes:


### PR DESCRIPTION
In Nextcloud wird eine Funktion denutzt, die es in der aktuellen mariadb nicht mehr gibt.