### PR TITLE
Dopplung entfernen, Hinweis

### DIFF
--- a/source/installation/install-from-scratch/basis_server.rst
+++ b/source/installation/install-from-scratch/basis_server.rst
@@ -290,7 +290,12 @@ Werde mit ``sudo -i`` root und editiere, beispielsweise mit nano, die Datei ``/e
 
 Ersetze bei ``APT::Periodic::Unattended-Upgrade`` die ``"1";`` durch ``"0";``. Mit ``<Strg>+o`` speicherst du die Änderung ab. Und mit ``<Strg>+x`` verlässt du nano wieder.
 
-Jetzt kannst du den Server mit ``apt-get update`` und anschließendem ``apt-get dist-upgrade`` updaten. 
+Jetzt kannst du den Server mit ``apt-get update`` und anschließendem ``apt-get dist-upgrade`` updaten.
+
+
+.. hint::
+
+   Es kann passieren, das sonst durch ein Update zur Unzeit unvorgesehene Probleme auftreten.
 
 cloud-init abschalten
 ---------------------
@@ -312,7 +317,6 @@ cloud-init abschalten
 
 .. code::
 
-      sudo dpkg-reconfigure cloud-init
       sudo apt-get purge cloud-init
       sudo rm -rf /etc/cloud/ && sudo rm -rf /var/lib/cloud/
 


### PR DESCRIPTION
Hinweis auf Konsequenz Autoupdate

Empfehlung: Rework: LVM in eigenes Kapitel verschieben, auf lmn-prepare setzen

Hinweis aus dem Zusammenhang gerissen:
Ohne LVM sind die Mount Points /var und /srv auf die 2. HDD zu legen. Die Zuordnung der Mount Points zum LVM wird später detailliert beschrieben.