### PR TITLE
Fix v7.4 doc inconsistencies (kernel version, LINBO version typo, broken reference)

### DIFF
--- a/source/about/what-is-new.rst
+++ b/source/about/what-is-new.rst
@@ -22,7 +22,7 @@ Moderne Betriebssystembasis und Steuerung
   * Aktuelle Betriebssysteme für die Server (Ubuntu Server 26.04 LTS)
   * **Optionale** Firewall OPNsense |reg| ab v26.1
   * Verbesserung der Performance des Samba-Dateiservers durch automatische Verlagerung der Shares auf eine zweite VM, die nur den Dateiserver aufnimmt. Nutzung von DFS als Dateisystem.
-  * Mit LINBO 7.6: aktuellste Linux-Kernels für aktuelle Hardware, differentielle Images, ntfs3 Kernel-Treiber, VNC-Server, mit neuem Namensschema zur einheitlichen Partitionierung
+  * Mit LINBO 7.4: aktuellste Linux-Kernels für aktuelle Hardware, differentielle Images, ntfs3 Kernel-Treiber, VNC-Server, mit neuem Namensschema zur einheitlichen Partitionierung
   * Webbasierte Steuerung der pädagogischen Funktionen mit einem **responsive design** (passt sich an alle Bildschirmgrößen und -auflösungen an).
   * WebUI mit vielen neuen administrativen Möglichkeiten wie die Verwaltung von Schulpersonal und Eltern
   * Bereitstellung von linuxmuster-tools, linuxmuster-api und linuxmuster-cli mit erweiterten Möglichkeiten zur Administration und Anbindung externer webbasierter Systeme

--- a/source/clients/use_linbo4/index.rst
+++ b/source/clients/use_linbo4/index.rst
@@ -1027,7 +1027,7 @@ Auf dem Server befindet sich unter ``/etc/linuxmuster/linbo/custom_kernel.ex`` e
 
 Kopiere die Datei Vorlage ``/etc/linuxmuster/linbo/custom_kernel.ex`` nach ``/etc/linuxmuster/linbo/custom_kernel``. Editiere diese Datei nun so, dass der gewünschte Kernel auf dem Client gebootet wird. Sind in der Datei alle Zeilen auskommentiert, dann startet der Client einen letzten stable Kernel.
 
-- Es kann alternativ der **5.15er Kernel (legacy)** genutzt werden. Dazu müssen einfach in der Datei ``/etc/linuxmuster/linbo/custom_kernel`` die folgenden Zeilen eingetragen werden. Es ist nur das Kommentarzeichen für die zweite Zeile zu entfernen.
+- Es kann alternativ der **6.1er Kernel (legacy)** genutzt werden. Dazu müssen einfach in der Datei ``/etc/linuxmuster/linbo/custom_kernel`` die folgenden Zeilen eingetragen werden. Es ist nur das Kommentarzeichen für die zweite Zeile zu entfernen.
 
 .. code::
 
@@ -1132,7 +1132,7 @@ Kernel-Options verwenden
 ------------------------
 
 Auf dem Server findet sich pro Hardwareklasse eine start.conf Datei unter: ``/srv/linbo/start.conf.<Hardwareklasse>``
-Um Besonderheiten einzelner Hardwareklassen anzupassen, gibt es den Eintrag **KernelOptions_**. 
+Um Besonderheiten einzelner Hardwareklassen anzupassen, gibt es den Eintrag **KernelOptions**.
 
 .. code::
      


### PR DESCRIPTION
## Summary
- `source/clients/use_linbo4/index.rst`: the "LINBO-Kernel wechseln" section still described the legacy channel as the "5.15er Kernel", but the legacy channel was updated to 6.1.x a while ago (matches the channel table at the top of the same chapter and linuxmuster-linbo7's changelog).
- `source/about/what-is-new.rst`: "Mit LINBO 7.6" should be "Mit LINBO 7.4" — all linuxmuster.net core packages (Base, Linbo, WebUI, Tools, API, CLI, Sophomorix) now share the 7.4.x release version scheme, and `about.rst` already uses "LINBO 7.4" correctly for the same feature.
- `source/clients/use_linbo4/index.rst`: `**KernelOptions_**` was an unresolved Sphinx hyperlink reference (no target named "KernelOptions" exists, the section is titled "Kernel-Options verwenden") — removed the trailing underscore so it's just bold text for the config key name.

## Test plan
- [ ] Sphinx build to confirm no more "unknown target name" warning for KernelOptions