### PR TITLE
Fix spelling/grammar in v7.4 doc changes

### DIFF
--- a/source/about/about.rst
+++ b/source/about/about.rst
@@ -10,14 +10,14 @@ Was ist linuxmuster.net?
 
 linuxmuster.net ist eine Komplettlösung für den digital unterstützten Unterricht für Schüler:innen und Lehrer:innen einer zeitgemäßen Bildungseinrichtung.
 
-Die langjährigen Erfahrungen aller Beteiligten aus der linuxmuster.net Gemeinde haben gezeigt, dass sich ein Firnmennetzwerk fundamental von den Anforderungen an ein 
-heutige Schulnetz unterscheiden. 
+Die langjährigen Erfahrungen aller Beteiligten aus der linuxmuster.net Gemeinde haben gezeigt, dass sich ein Firmennetzwerk fundamental von den Anforderungen an ein
+heutiges Schulnetz unterscheidet.
 
 Die Entwicklung von linuxmuster.net greift all diese Anforderungen auf und stellt eine modulare Lösung für ein Schulnetz zur Verfügung. 
 
 Diese kann von einer Ein-Server-Lösung (mit drei virtuellen Maschinen - VMs) bis hin zu einer Mehr-Server-Lösung mit Cloud-Anbindung und BYOD-Integration und mehreren physikalischen Servern skaliert werden.
 
-Die Anforderungen, die heute an ein Schulnetz gestellt werden, erklären wir im nachfolgenden Abschnitten detailliert. Im Anschluss zeigen wir auf, wie linuxmuster.net diese umsetzt.
+Die Anforderungen, die heute an ein Schulnetz gestellt werden, erklären wir in den nachfolgenden Abschnitten detailliert. Im Anschluss zeigen wir auf, wie linuxmuster.net diese umsetzt.
 
 Schulnetzwerk vs. "normales" Netzwerk
 =====================================
@@ -68,13 +68,13 @@ Im Prinzip gibt es vier große Merkmale, die auffallen:
 
    Zum Schuljahreswechsel verlässt eine große Anzahl an Schüler:innen die Einrichtung und neue Schüler:innen müssen in das System eingepflegt werden. Die Zusammensetzung der Klassen, Kurse und Arbeitsgruppen werden zu großen Teilen neu formiert, so dass Änderungen an bestehenden Schüler:innen erforderlich sind.
 
-   Solch ein administrativen Aufwand ergibt sich in einer Firma selten.
+   Solch ein administrativer Aufwand ergibt sich in einer Firma selten.
 
 4. Der Umgang mit den Arbeitsmitteln
 
    Schüler:innen teilen sich ein und dasselbe Arbeitsmittel im schulischen Alltag. Dabei ist es für die nächste Unterrichtseinheit entscheidend, dass zum Start immer eine einheitliche und funktionsfähige Umgebung auf den Rechnern vorhanden ist. Die zeitliche Taktung zwischen den Wechseln kann sehr kurz sein.
 
-   Dies ist in einer Firma so nicht gegeben. Wenn ein User seinen Rechner verlässt, findet er ihn der Regel immer genauso wieder.
+   Dies ist in einer Firma so nicht gegeben. Wenn ein User seinen Rechner verlässt, findet er ihn in der Regel immer genauso wieder.
 
 Aus diesen Gründen sprechen wir von einem
 
@@ -99,7 +99,7 @@ Unser Anspruch liegt dabei auf der Bereitstellung eines Systems, das folgende Pu
    :name:     structure-over-all 
    :alt:      gesamte Struktur
 
-Ein Augenmerk liegt dabei auf der Unabhängigkeit eingesetzter Hard- und Software. Dieses wird unter anderem an dem Umfang der unterstützten Betriebssysteme für die Arbeitsstationen erkennbar.
+Ein Augenmerk liegt dabei auf der Unabhängigkeit eingesetzter Hard- und Software. Dies wird unter anderem an dem Umfang der unterstützten Betriebssysteme für die Arbeitsstationen erkennbar.
 
 Proprietäre Betriebssysteme, |zb| aus dem Hause Microsoft |reg|, können aufgrund der Lizenzpolitik der Hersteller nicht von uns vorbereitet ausgeliefert werden. Diese lassen sich aber ebenso leicht in unsere Infrastruktur integrieren, wie solche, die als Open-Source erhältlich sind.
 
@@ -141,7 +141,7 @@ Die Benutzer- und Gruppenverwaltung orientiert sich an den Bedürfnissen, die de
 
     * Schüler:innen bekommen mit der Einschulung ihren persönlichen Benutzer-Account.
     * Dieser bleibt ihnen bis zum Ende ihrer Laufbahn an der Schule erhalten.
-    * Die Gruppenzugehörigkeit der einzelnen Schüler:innen werden in Klassen, Kursen und Projekten abgebildet.
+    * Die Gruppenzugehörigkeit der einzelnen Schüler:innen wird in Klassen, Kursen und Projekten abgebildet.
     * Zu Beginn eines Schuljahres können diese Daten und Abhängigkeiten aus der Schulverwaltung mittels Import der Daten eingespielt bzw. fortgeschrieben werden.
       Gleiches gilt selbstverständlich auch für Veränderungen während eines laufenden Schuljahres.
     * Für Lehrer:innen gilt dies ebenso.
@@ -195,7 +195,7 @@ Für weitergehende Informationen `siehe opnsense.org <https://opnsense.org/>`_.
 
 Bestehende Firewall
 ^^^^^^^^^^^^^^^^^^^
-Es kann auch eine bestehende Firewall weiter genutzt und vollständig in linuxmuster.net integriert werden. Da diese Intergration von deren verwendeten Betriebssystem abhängt und unterschiedliche Schritte erfordert, können wir nicht eine datailierte Anleitung hier aufzeigen. Geben aber Hinweise dazu im Kapitel `Anpassbar`_. 
+Es kann auch eine bestehende Firewall weiter genutzt und vollständig in linuxmuster.net integriert werden. Da diese Integration von deren verwendeten Betriebssystem abhängt und unterschiedliche Schritte erfordert, können wir nicht eine detaillierte Anleitung hier aufzeigen. Geben aber Hinweise dazu im Kapitel `Anpassbar`_. 
 
   
 Selbstheilende Arbeitsstationen durch LINBO 7.4
@@ -216,7 +216,7 @@ Das Konzept der Selbstheilenden Arbeitsstationen (SheilA) ermöglicht einheitlic
     * Möglichkeit sich via VNC auf den LINBO-Client aufzuschalten.
     * mit sogenannten Postsync-Scripten kann der Administrator für einzelne, raumweite oder für alle Geräte notwendige Konfigurationsänderungen beim Systemstart einpflegen.
 
-Nähere Information sind im Kapitel "Clientverwaltung" beschrieben.
+Nähere Informationen sind im Kapitel "Clientverwaltung" beschrieben.
 
 Integration unterschiedlicher Geräte (BYOD)
 +++++++++++++++++++++++++++++++++++++++++++

--- a/source/about/what-is-new.rst
+++ b/source/about/what-is-new.rst
@@ -22,7 +22,7 @@ Moderne Betriebssystembasis und Steuerung
   * Aktuelle Betriebssysteme für die Server (Ubuntu Server 26.04 LTS)
   * **Optionale** Firewall OPNsense |reg| ab v26.1
   * Verbesserung der Performance des Samba-Dateiservers durch automatische Verlagerung der Shares auf eine zweite VM, die nur den Dateiserver aufnimmt. Nutzung von DFS als Dateisystem.
-  * Mit LINBO 7.6: aktuellste Linux-Kernels für aktuelle Hardware, differentielle Images, ntfs3 Kernel-Treiber, VNC-Server, mit neuem Namensschema zur einheitlichen Partitionierung
+  * Mit LINBO 7.4: aktuellste Linux-Kernels für aktuelle Hardware, differentielle Images, ntfs3 Kernel-Treiber, VNC-Server, mit neuem Namensschema zur einheitlichen Partitionierung
   * Webbasierte Steuerung der pädagogischen Funktionen mit einem **responsive design** (passt sich an alle Bildschirmgrößen und -auflösungen an).
   * WebUI mit vielen neuen administrativen Möglichkeiten wie die Verwaltung von Schulpersonal und Eltern
   * Bereitstellung von linuxmuster-tools, linuxmuster-api und linuxmuster-cli mit erweiterten Möglichkeiten zur Administration und Anbindung externer webbasierter Systeme

--- a/source/about/what-is-new.rst
+++ b/source/about/what-is-new.rst
@@ -58,7 +58,7 @@ Selbstheilende Arbeitsstationen
   * Weitere Neuerungen in LINBO sind u.a.:
 
     * Aktuelle Linux-Kernel ab 6.12.* und einem nativen NTFS-Kernel Treiber
-    * Neues einheitliches Partitionsschema mit neuem Namenschemata
+    * Neues einheitliches Partitionsschema mit neuem Namensschema
     * Konsolidierung der Start-Parameter
     * VNC-Server auf den Clients für Remote-Zugriff
     * Inventarisierung der Clients mit hwinfo

--- a/source/classroom/access-control.rst
+++ b/source/classroom/access-control.rst
@@ -7,7 +7,7 @@
 
 In einer Klasse und einem Kurs kann einzelnen Personen oder dem gesamten Kurs / der Klasse die Berechtigung zu Drucken oder der Zugriff auf WLAN und Internet gegeben oder genommen werden. Voraussetzung für diese Funktionen ist die :ref:`Aufnahme des Schülers <session-setup-label>` in einen Kurs.
 
-Öffne in der Schulkonsole unter ``KLASSENZIMMER -> Kurse`` wähle die geünschte Klasse oder den gewünschten Kurs.
+Öffne in der Schulkonsole unter ``KLASSENZIMMER -> Kurse`` wähle die gewünschte Klasse oder den gewünschten Kurs.
 
 .. figure:: media/webui-teachers-select-session.png
    :align: center
@@ -15,7 +15,7 @@ In einer Klasse und einem Kurs kann einzelnen Personen oder dem gesamten Kurs / 
    
    Wähle die Klasse / Gruppe aus
 
-Es wird Liste mit Schülern des Kurses bzw. der Klasse angezeigt. 
+Es wird eine Liste mit Schülern des Kurses bzw. der Klasse angezeigt.
 
 .. figure:: media/webui-teachers-list-session.png
    :align: center
@@ -36,7 +36,7 @@ Für jeden einzelnen und für alle Schüler können folgende Funktionen aktivier
    
    Spalten mit den zu-/abschaltbaren Funktionen pro Schüler
    
-Soll eine Funktion für alle Schüler aktiviert werden, klickst Du nur auf das Symbol des Spaltenkopfen (z.B. WLAN).
+Soll eine Funktion für alle Schüler aktiviert werden, klickst Du nur auf das Symbol des Spaltenkopfes (z.B. WLAN).
 
 .. figure:: media/webui-teachers-session-columns-wlan-activated.png
    :align: center

--- a/source/classroom/exam-and-transfer.rst
+++ b/source/classroom/exam-and-transfer.rst
@@ -24,7 +24,7 @@ in einen Kurs/Klasse.
    
    Starte die Session für die Klasse
 
-Hast Du einen Kurse / eine Klasse ausgewählt, wird Dir die Liste mit Schülern des Kurses / der Klasse angezeigt. 
+Hast Du einen Kurs / eine Klasse ausgewählt, wird Dir die Liste mit Schülern des Kurses / der Klasse angezeigt.
 
 .. figure:: media/webui-teachers-session-members.png
    :align: center
@@ -34,7 +34,7 @@ Hast Du einen Kurse / eine Klasse ausgewählt, wird Dir die Liste mit Schülern 
 
 Du kannst den Prüfungsmodus entweder für alle zusammen über das Prüfungssymbol im Spaltenkopf aktivieren.
 
-Alternativ kannst Du für einzelne Prüflingen den Prüfungsmodus starten, indem Du in der Zeile des Prüflings das Prüfungssymbol klikcst.
+Alternativ kannst Du für einzelne Prüflingen den Prüfungsmodus starten, indem Du in der Zeile des Prüflings das Prüfungssymbol klickst.
 
 .. figure:: media/exam-icon.png
    :align: center
@@ -116,7 +116,7 @@ Danach erscheint eine Rückfrage zur Bestätigung:
    
    Bestätige das Beenden des Prüfungsmodus
    
-Du erhälst ein Fenster mit der Nachfrage, ob Du den Prüfungsmodus wirklich beenden möchstest. Hast Du alle gewünschten Daten der Prüflinge zuvor eingesammelt, bestätige diesen Vorgang mit ``PRÜFUNGSMODUS BEENDEN``.
+Du erhältst ein Fenster mit der Nachfrage, ob Du den Prüfungsmodus wirklich beenden möchtest. Hast Du alle gewünschten Daten der Prüflinge zuvor eingesammelt, bestätige diesen Vorgang mit ``PRÜFUNGSMODUS BEENDEN``.
 
 .. figure:: media/webui-teachers-session-members.png
    :align: center
@@ -136,7 +136,7 @@ Ablauf der Prüfung
 1. Der Lehrer meldet sich an der Schulkonsole an.
 2. Der Lehrer wählt unter KLASSENzimmer -> Kurs -> Klasse die gewünschte Klasse aus.
 3. Der Lehrer aktiviert mit dem Prüfungssymbol den Prüfungsmodus.
-4. Der Lehrer teilt den Prüflingen im Raum mit wie diese sich am PC für die Prüfung anmelden müssen (<bisherigsLogin>+"-exam" & bisheriges Kennwort).
+4. Der Lehrer teilt den Prüflingen im Raum mit wie diese sich am PC für die Prüfung anmelden müssen (<bisheriger Login>+"-exam" & bisheriges Kennwort).
 5. Der Lehrer teilt die Prüfungen und ggf. weitere Vorlagen an die Prüfungsteilnehmer aus.
 6. Die Dateien liegen für die Prüfungsteilnehmer im Verzeichnis ``transfer/LEHRER/``.
 7. Schüler nutzen die bereitgestellten Daten und erstellen ihre Lösungen.
@@ -322,7 +322,7 @@ Der Lehrer sieht in der Schulkonsole die abgegebenen Dateien. Um die Liste mit d
    Prüfung: abgegebene Dateien einsehen
    
 Um vor Abschluss der Prüfung alle Abgaben einzusammeln, klickst Du unten links auf ``Von allen einsammeln``.
-Klicke nun auf ``Move _collect cirectory from all members``. Es werden nun alle Abgaben in das Verzeichnis des Lehrers zum Einsammeln der Dateien verschoben.
+Klicke nun auf ``Move _collect directory from all members``. Es werden nun alle Abgaben in das Verzeichnis des Lehrers zum Einsammeln der Dateien verschoben.
 
 .. figure:: media/webui-exam-collect-all-files.png
    :align: center
@@ -338,17 +338,17 @@ Klicke nun auf ``Move _collect cirectory from all members``. Es werden nun alle 
 Prüfung beenden
 ^^^^^^^^^^^^^^^
 
-Nachdem alle Dateien eingsammelt wurden, beendet der Lehrer den Prüfungsmodus.
+Nachdem alle Dateien eingesammelt wurden, beendet der Lehrer den Prüfungsmodus.
 
 Hierzu klickst Du auf das rot hinterlegte Prüfungssymbol im Spaltenkopf, um für alle Prüflingen den Prüfungsmodus zu beenden.
 
-Sollten für Prüflinge untzerschiedliche Prüfungszeiten gelten, so beendest Du pro Prüfling deren Prüfung zeilenweise einzeln.
+Sollten für Prüflinge unterschiedliche Prüfungszeiten gelten, so beendest Du pro Prüfling deren Prüfung zeilenweise einzeln.
 
 Abgaben einsehen
 ^^^^^^^^^^^^^^^^
 
 Du kannst als Lehrer wähend der Prüfung bereits eingesammelte Ordner und Dateien einsehen. Gehe hierzu unten auf ``Eingesammelte Dateien durchschauen``
-Es öffnet sich ein Fenster mit den einsammelten Ordnern und Dateien.
+Es öffnet sich ein Fenster mit den eingesammelten Ordnern und Dateien.
 
 .. figure:: media/webui-exam-check-collected-directories.png
    :align: center
@@ -357,7 +357,7 @@ Es öffnet sich ein Fenster mit den einsammelten Ordnern und Dateien.
 
    Prüfung: Prüfe Dateiabgaben
 
-Die aktuelle Prüfung ist am Klassennamen und an dem Zeistempel zu erkennen. Klicke auf das Ordnersymbol, um diesen zu öffnen.
+Die aktuelle Prüfung ist am Klassennamen und an dem Zeitstempel zu erkennen. Klicke auf das Ordnersymbol, um diesen zu öffnen.
 
 .. figure:: media/webui-exam-check-collected-directories-of-users.png
    :align: center

--- a/source/classroom/webui-basics/index.rst
+++ b/source/classroom/webui-basics/index.rst
@@ -109,7 +109,7 @@ Klassenzimmer
 Kurs
 ----
 
-In dem Menüpunkt Kurs werden der aktuelle Raum, Deine zugeordneten Klassen, Deine Gruppenund Projekte aufgelistet.
+In dem Menüpunkt Kurs werden der aktuelle Raum, Deine zugeordneten Klassen, Deine Gruppen und Projekte aufgelistet.
 
 .. figure:: media/10_webui-basics_my-classes.png
    :align: center
@@ -176,7 +176,7 @@ Um Schüler einer Gruppe hinzuzufügen, wählst Du die gewünschte Gruppe via Kl
    :align: center
    :alt: seclected course
    
-   Ausgwählter Kurs
+   Ausgewählter Kurs
 
 In den oberen Zeilen gibt es nun die Möglichkeit über ``Schüler hinzufügen`` einzelne Schüler hinzuzufügen oder über ``Klasse hinzufügen`` eine ganze Schulklasse dem Kurs hinzuzufügen. Klickst Du in das Feld ``Schüler hinzufügen`` und gibst dort die **ersten beiden Buchstaben des Schülernamens** ein, erscheint eine Liste mit Schülern, deren Nachnamen mit diesen Buchstaben beginnen.
 
@@ -184,7 +184,7 @@ In den oberen Zeilen gibt es nun die Möglichkeit über ``Schüler hinzufügen``
    :align: center
    :alt: add pupils to course
    
-   Ausgwählter Kurs: Schüler hinzufügen
+   Ausgewählter Kurs: Schüler hinzufügen
 
 Wähle einen einzelnen Schüler aus, der zur Gruppe hinzugefügt werden soll. Wiederhole diesen Vorgang für alle weiteren Schüler.
 
@@ -200,9 +200,9 @@ Die Gruppe ist nun erstellt.
 
 .. hint::
 
-   Bei einzelnen Schülern siehst Du noch einen roten Button in der Spalte Arbeitsverzeichnis. Dies liegt daran, dass für diese Schüler in Deinem Transferorrdner noch keine Verzeichnisse angelegt wurden.
+   Bei einzelnen Schülern siehst Du noch einen roten Button in der Spalte Arbeitsverzeichnis. Dies liegt daran, dass für diese Schüler in Deinem Transferordner noch keine Verzeichnisse angelegt wurden.
 
-   Sollte dies so sein, klicke danach im Menü links auf ``Kurs`` -> ``Meine Gruppen`` -> ``Neu erstellte Gruppe``. Danach erscheinen alle Schüler, die der Gruppe hinzugefügt wurden. Schließe die Einrichtung des Kurses mithilfe des Klicks auf den roten Button ab, der alle Schüler auflistest, für die noch kein Verzeichnis im Transferordner angelegt wurde. Zur Bestätigung musst Du Dein Anmeldekennwort angeben.
+   Sollte dies so sein, klicke danach im Menü links auf ``Kurs`` -> ``Meine Gruppen`` -> ``Neu erstellte Gruppe``. Danach erscheinen alle Schüler, die der Gruppe hinzugefügt wurden. Schließe die Einrichtung des Kurses mithilfe des Klicks auf den roten Button ab, der alle Schüler auflistet, für die noch kein Verzeichnis im Transferordner angelegt wurde. Zur Bestätigung musst Du Dein Anmeldekennwort angeben.
 
 Klickst Du nun auf Kurs, siehst Du folgende Ansicht:
 
@@ -310,7 +310,7 @@ Das Absolventenkappen-Symbol
 
    Prüfungsmodus
 
-stellt den Prüfungsmodus dar. Ausgewählte Schüler oder alle Schüler einer Klasse eines Kurses können dadurch in diesen Modus gesetzt werden. Um alle Schüler des Kurses in den Prüfungsmodus zu versetzen, klickst Du auf das Icon für den Prüfungsmodus im Spaltenkopf. Sollen nur einzelne Schüler in den Prüfungsmodus versetzt werden, wäjlst Du dies Symbol bei dem jeweiligen Schüler aus.
+stellt den Prüfungsmodus dar. Ausgewählte Schüler oder alle Schüler einer Klasse eines Kurses können dadurch in diesen Modus gesetzt werden. Um alle Schüler des Kurses in den Prüfungsmodus zu versetzen, klickst Du auf das Icon für den Prüfungsmodus im Spaltenkopf. Sollen nur einzelne Schüler in den Prüfungsmodus versetzt werden, wählst Du dies Symbol bei dem jeweiligen Schüler aus.
 
 Im aktivierten Prüfungsmodus wird die Seite wie folgt angezeigt:
 
@@ -334,12 +334,12 @@ Im Menü ``Einschreiben`` findest Du nachstehende drei Rubriken.
 Schulklassen
 ^^^^^^^^^^^^
    
-Hier werden alle Schulklassen der Schule aufgelistet. Durch Klick auf den Klassennamen werden Dir weitere Informationen angezeigt, wie etwa alle Schüler der Klasse. Um Dir eine schulklasse zuzuordnen aktivierst Du den Haken vor der Klasse und bestätigst dann die Ausführung oben auf der Seite mit ``Jetzt ausführen``.
+Hier werden alle Schulklassen der Schule aufgelistet. Durch Klick auf den Klassennamen werden Dir weitere Informationen angezeigt, wie etwa alle Schüler der Klasse. Um Dir eine Schulklasse zuzuordnen aktivierst Du den Haken vor der Klasse und bestätigst dann die Ausführung oben auf der Seite mit ``Jetzt ausführen``.
 
 Drucker
 ^^^^^^^
 
-Hier werden alle Drucker aufgelistet. Durch Anklicken werden weitere Informationen angezeigt. Drucker müssen zuvor vom Administrator angelegt und eingerichtet worden sein, damit diese hier erscheinen..
+Hier werden alle Drucker aufgelistet. Durch Anklicken werden weitere Informationen angezeigt. Drucker müssen zuvor vom Administrator angelegt und eingerichtet worden sein, damit diese hier erscheinen.
 
 Ein Auswählen ist nur erforderlich, wenn man den Drucker auch außerhalb des zugehörigen Raumes nutzen möchte.
 
@@ -352,7 +352,7 @@ Projekte
 
    - Gruppe: Eine Gruppe hat kein Netzlaufwerk (keine Shares), um Dateien gemeinsam abzulegen und auszutauschen. Zudem kann diesen keine E-Mail zugeordnet werden. Insofern ist es nur eine Liste mit Benutzer für einen Kurs (z.B. eine einmalige Schulung).
 
-   - Projekt: Ist ein Zusammenschluss mehrerer Benutzer aus verswchiedenen Gruppen, mit einem gemeinsamen Projektlaufwerk (also mit Shares) und der Möglichkeit, hiermit einen Projektverteiler zu erstellen, um via E-Mail Infos weiterzugeben. Letzters erfordert aber eine Konfiguration des SMTP-Relais und ggf. der Edulution UI.
+   - Projekt: Ist ein Zusammenschluss mehrerer Benutzer aus verschiedenen Gruppen, mit einem gemeinsamen Projektlaufwerk (also mit Shares) und der Möglichkeit, hiermit einen Projektverteiler zu erstellen, um via E-Mail Infos weiterzugeben. Letzters erfordert aber eine Konfiguration des SMTP-Relais und ggf. der Edulution UI.
 
 
 Hier werden alle Deine Projekte aufgelistet. Um ein neues Projekt anzulegen, klicke auf ``Neues Projekt`` und trage den Projektnamen ein.
@@ -384,7 +384,7 @@ Klickst Du auf das Projekt - hier ``P_netzwerkguide`` siehst Du alle Einstellung
 
 Um dem neu angelegten Projekt Projektmitglieder hinzuzufügen, klickst Du wie oben dargestellt auf den Button ``Benutzer oder Gruppe hinzufügen``.
 
-Um einzelne Benutzer hinzuzufügen, klikcst Du in das Feld ``Nach einem Benutzer suchen`` und gibst dort einige Buchstaben des Names des Benutzers ein. Es werden alle gefundenden Einträge in einer Liste angezeigt. Aus dieser kannst Du einen gewünschten Benutzer auswählen.
+Um einzelne Benutzer hinzuzufügen, klickst Du in das Feld ``Nach einem Benutzer suchen`` und gibst dort einige Buchstaben des Names des Benutzers ein. Es werden alle gefundenen Einträge in einer Liste angezeigt. Aus dieser kannst Du einen gewünschten Benutzer auswählen.
 
 .. figure:: media/23_webui-basics_new_project_add_project_members.png
    :align: center
@@ -392,7 +392,7 @@ Um einzelne Benutzer hinzuzufügen, klikcst Du in das Feld ``Nach einem Benutzer
 
    Projektmitglieder hinzufügen
 
-Diesen Vorgang wiederholst Du für alle gewünschten Benutzer, Schüler aus einer Klasse oder Projektmitglieder anderer Projekte. Alle ausgewählten Benutzer werden ann unter ``Hinzufügen`` aufgelistet.
+Diesen Vorgang wiederholst Du für alle gewünschten Benutzer, Schüler aus einer Klasse oder Projektmitglieder anderer Projekte. Alle ausgewählten Benutzer werden dann unter ``Hinzufügen`` aufgelistet.
 
 .. figure:: media/23_webui-basics_new_project_add_project_members2.png
    :align: center

--- a/source/clients/client_templates/os_installation/linux-clients/index.rst
+++ b/source/clients/client_templates/os_installation/linux-clients/index.rst
@@ -376,7 +376,7 @@ Trage das linuxmuster.net Repository in die Paketquellen des Clients ein:
 
 .. code::
 
-   sudo sh -c 'echo "deb [arch=amd64 signed-by=/usr/share/keyrings/linuxmuster.net.gpg] https://deb.linuxmuster.net/ lmn73 main" > /etc/apt/sources.list.d/lmn73.list'
+   sudo sh -c 'echo "deb [arch=amd64 signed-by=/usr/share/keyrings/linuxmuster.net.gpg] https://deb.linuxmuster.net/ lmn74 main" > /etc/apt/sources.list.d/lmn74.list'
 
 Aktualisiere die Paketinformationen mit ``sudo apt update``.
 

--- a/source/clients/client_templates/os_installation/linux-clients/index.rst
+++ b/source/clients/client_templates/os_installation/linux-clients/index.rst
@@ -69,7 +69,7 @@ Installation Ubuntu
 .. hint::
    Bei Ubuntu sollte man darauf achten, dass der Firefox nicht als Snap-Paket installiert wird, da damit SSO nicht funktioniert! Möglicherweise trifft das auch auf andere Distributionen zu!
    
-Hast Du den PC / die VM von vom ISO-Image / der Installations-DVD gestartet, siehst Du zunächst folgenden Start-Bildschirm:
+Hast Du den PC / die VM vom ISO-Image / der Installations-DVD gestartet, siehst Du zunächst folgenden Start-Bildschirm:
 
 .. figure:: media/00-linux-client-ubu-grub-start.png
    :align: center
@@ -184,11 +184,11 @@ Klicke auf ``ok`` und es werden nochmals alle Einstellungen angezeigt:
    
    Übersicht der Partitionen
 
-Sind diese Einstellungen korrekt, prüfe noch, ob das Gerät für die Bootloader-Installation die Ubuntu-Parition ist bzw. bei UEFI-Geräte EFI-Partition (z.B. /dev/vda1 hier mit dem Einhängepunkt /boot/efi). Falls nicht passe dies an. Der Bootloader sollte **nicht** auf den MBR der Festplatte installiert werden.
+Sind diese Einstellungen korrekt, prüfe noch, ob das Gerät für die Bootloader-Installation die Ubuntu-Parition ist bzw. bei UEFI-Geräten EFI-Partition (z.B. /dev/vda1 hier mit dem Einhängepunkt /boot/efi). Falls nicht passe dies an. Der Bootloader sollte **nicht** auf den MBR der Festplatte installiert werden.
 
 Setze die Installation mit dem Button ``weiter`` fort.
 
-Im weiteren INstallationsverlauf wirst Du nach dem Namen für den Computer und dem Benutzernamen und Kennwort für den neuen Administrator gefragt. Gib hier als Benutzernamen ``linuxadmin`` ein. Beim Namen des Rechners musst Du den Namen des PCs / der VM angeben, wie Du ihn in der Gerätekonfiguration festgelegt hast.
+Im weiteren Installationsverlauf wirst Du nach dem Namen für den Computer und dem Benutzernamen und Kennwort für den neuen Administrator gefragt. Gib hier als Benutzernamen ``linuxadmin`` ein. Beim Namen des Rechners musst Du den Namen des PCs / der VM angeben, wie Du ihn in der Gerätekonfiguration festgelegt hast.
 
 .. figure:: media/05-linux-client-ubu-install.png
    :align: center
@@ -217,7 +217,7 @@ Vor der eigentlichen Installation werden Dir die Einstellungen nochmals als Übe
 
 Entsprechen die angezeigten Einstellungen den von Dir gewünschten Einstellungen, dann starte die Installation mit dem Button ``Installieren``.
 
-Während der Installation wir Dir der Status des Vorgangs dargestellt.
+Während der Installation wird Dir der Status des Vorgangs dargestellt.
 
 .. figure:: media/05-linux-client-ubu-installation-status.png
    :align: center
@@ -256,7 +256,7 @@ Klicke nun unten rechts auf das Werkzeug-Symbol, um zum Menü für die Imageerst
    :align: center
    :alt: Ubuntu Installation: Menue Tools
    
-   Wekzeug-Symbol
+   Werkzeug-Symbol
 
 Du wirst nach dem Linbo-Passwort gefragt. Gib dieses ein. 
 
@@ -324,7 +324,7 @@ Zum Abschluss erscheint die Meldung, dass das Image erfolgreich hochgeladen wurd
 
 Gehe durch einen Klick auf das Zeichen ``<`` zurück und klicke im nächsten Bildschirm das obere Symbol auf der rechten Seite an, um Dich abzumelden.
 
-Du siehst nun drei Start-Symbole. Das grosse Symbol started das Image sychronisiert, während das grüne Icon das lokale Image aus dem Cache ohne Synchronisation startet.
+Du siehst nun drei Start-Symbole. Das große Symbol startet das Image synchronisiert, während das grüne Icon das lokale Image aus dem Cache ohne Synchronisation startet.
 
 .. figure:: media/06-linux-client-ubu-install.png
    :align: center

--- a/source/clients/use_linbo4/index.rst
+++ b/source/clients/use_linbo4/index.rst
@@ -1106,7 +1106,7 @@ Gibt dmesg folgenden Fehler aus:
    i915 0000:00:02.0: [drm] Failed to load DMC firmware i915/kbl_dmc_ver1_04.bin. Disabling runtime power management.
    i915 0000:00:02.0: [drm] DMC firmware homepage: https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git/tree/i915
 
-Dann passe die Datei wir folgt an:
+Dann passe die Datei wie folgt an:
 
 .. code::
 
@@ -1125,7 +1125,7 @@ Führe anschließend den Befehl ``update-linbofs`` auf dem linuxmuster Server au
 
 .. hint::
 
-   Sollte ein geladener Wifi Treiber dazu führen, dass die Wifi NIC nicht nach einem LINBO Reboot funktioniert, dann nutze die Kerneloption ``nowarmstart``.
+   Sollte ein geladener Wifi-Treiber dazu führen, dass die Wifi-NIC nicht nach einem LINBO Reboot funktioniert, dann nutze die Kerneloption ``nowarmstart``.
 
 
 Kernel-Options verwenden
@@ -1143,7 +1143,7 @@ Um Besonderheiten einzelner Hardwareklassen anzupassen, gibt es den Eintrag **Ke
      # Modul realtek r8168 laden, aber den Aufruf des Moduls realtek r8169 unterbinden
      KernelOptions = loadmodules=r8168 modprobe.blacklist=r8169
      
-     # lade noche keine Grafikkarten-Treiber, bis das System gestartet wurde und lade diese erst danach. 
+     # lade noch keine Grafikkarten-Treiber, bis das System gestartet wurde und lade diese erst danach.
      KernelOptions = nomodeset
      
      # linbo soll nach dem herunterladen eines neuen LINBO-Kernels keinen Warmstart ausführen  
@@ -1204,11 +1204,11 @@ Dies kann auf dem PC wie folgt in der Linux-Konsole definiert werden:
 
    ssh -L 9999:<Client-IP>:9999 root@<Server-IP>
    
-Der Server fordert zur Eingabe des Kennwortes für den Benutzer root auf. Wurde dies erfolgreich ausgeführt, so ist die Konsole es Server zu sehen.
+Der Server fordert zur Eingabe des Kennwortes für den Benutzer root auf. Wurde dies erfolgreich ausgeführt, so ist die Konsole des Servers zu sehen.
 
 Auf dem Client kann nach dem LINBO-Bootvorgang in der LINBO-Konsole kontrolliert werden, ob der VNCServer gestartet wurde. Wähle in LINBO dazu rechts das Werkzeug aus und wähle den Eintrag LINBO-Konsole aus.
 
-Gib hier den Befehl ``ps`` ein und Du erhälst die Ausgabe der derzeit unter LINBO auf dem Client laufende Prozesse.
+Gib hier den Befehl ``ps`` ein und Du erhältst die Ausgabe der derzeit unter LINBO auf dem Client laufende Prozesse.
 
 Dies kann z.B. wie folgt aussehen:
 
@@ -1251,7 +1251,7 @@ Mit LINBO >= v4.3 ist es möglich via LINBO ein Live-System wie z.B. Ubuntu 24.0
 
 Um im Fehlerfall auf bestimmten Clients diesen auch mithilfe eines Live-System zu booten, kann z.B. für eine Hardwareklasse ein zusätzlicher Boot-Eintrag bereitgestellt werden, der auf eine ISO-Datei verweist.
 
-Hierdurch kannst Du via LINBO auf dem Client das Live-System vom Server aus starten und so die Fehler auf dem Client anaylsieren, oder auch einfach nur das Live-System auf dem Client testen.
+Hierdurch kannst Du via LINBO auf dem Client das Live-System vom Server aus starten und so die Fehler auf dem Client analysieren, oder auch einfach nur das Live-System auf dem Client testen.
 
 Vorgehen
 --------
@@ -1273,7 +1273,7 @@ Pro ISO-Datei ist  unterhalb des o.g. Verzeichnisses ein gleichnamiges Unterverz
 
 **Beispiel**:
 
-Sollen die ISO-Dateien ``ubuntu-24.04.2-desktop-amd64.iso`` und ``systemrescue-12.01-amd64.iso`` bereitgestellt werden, so sind zunächst folge unterverzeichnisse anzulegen:
+Sollen die ISO-Dateien ``ubuntu-24.04.2-desktop-amd64.iso`` und ``systemrescue-12.01-amd64.iso`` bereitgestellt werden, so sind zunächst folgende Unterverzeichnisse anzulegen:
 
 .. code::
 
@@ -1301,7 +1301,7 @@ Dies erfolgt bezogen auf o.g. Beispiel mit nachstehenden Befehlen:
    linbo-torrent create /srv/linbo/images/ubuntu-24.04.2-desktop-amd64/ubuntu-24.04.2-desktop-amd64.iso
    linbo-torrent create /srv/linbo/images/systemrescue-12.01-amd64/systemrescue-12.01-amd64.iso
    
-Es finden sich in in dem jeweiligen Unterverzeichnis dann drei Dateien (z.B.):
+Es finden sich in dem jeweiligen Unterverzeichnis dann drei Dateien (z.B.):
 
 .. code::
 
@@ -1312,7 +1312,7 @@ Es finden sich in in dem jeweiligen Unterverzeichnis dann drei Dateien (z.B.):
 Pfade für Kernel und Initrd ermitteln
 -------------------------------------
 
-In der Hardwareklasse sind später die Pfade für Kernel und Initd anzugeben, wie diese in der ISO-Datei gültig sind. Daher sind in den ISO-Dateien zunächst deren Pfade zu ermitteln.
+In der Hardwareklasse sind später die Pfade für Kernel und Initrd anzugeben, wie diese in der ISO-Datei gültig sind. Daher sind in den ISO-Dateien zunächst deren Pfade zu ermitteln.
 
 1. Mounte die ISO-Datei auf dem PC
 2. Suche für den Kernel nach der Datei ``vmlinuz``. Notiere Dir den Pfad.
@@ -1326,7 +1326,7 @@ Für systemrescue-12.01-amd64.iso liegt die Datei ``vmlinuz`` im Verzeichnis ``s
 Kernel-Append-Parameter ermitteln
 ---------------------------------
 
-Für die ISO-Dateien musst Du noch ermitteln, welche Kernel-Parameter angefügt werden können2, die dann in der Hardwareklasse für die start.conf angegeben werden können.
+Für die ISO-Dateien musst Du noch ermitteln, welche Kernel-Parameter angefügt werden können, die dann in der Hardwareklasse für die start.conf angegeben werden können.
 
 1. Öffne die gemountete ISO-Datei auf dem PC.
 2. Suche die Dateien ``boot/grub/grub.cfg`` oder ``isolinux.cfg``. Die Parameter splash, quiet, findiso und iso-scan können weggelassen werden, da sie automatisch erzeugt werden.
@@ -1364,7 +1364,7 @@ Abschließend musst Du in der Konsole auf dem Server den Befehl ``linuxmuster-im
 Live-CD starten
 ---------------
 
-Starte nun den Client via LINBO. Im Startmenü von LINBO findest Du nun den zur angelegten Eintrag zur Live-CD. Starte diese nun durch einen Klick auf das grosse Symbol für das Betriebssystem.
+Starte nun den Client via LINBO. Im Startmenü von LINBO findest Du nun den angelegten Eintrag zur Live-CD. Starte diese nun durch einen Klick auf das große Symbol für das Betriebssystem.
 
 
 im Fehlerfall
@@ -1377,7 +1377,7 @@ Nutzt Du sehr große Images, so kann es passieren, dass bei der Verteilung der q
 
 Ab LINBO v4.1.36 können für ``ctorrent`` Parameter angepasst werden, um dies zu verhindern.
 
-Die Konfigurationsdati für ctorrent befindet sich 
+Die Konfigurationsdatei für ctorrent befindet sich
 
 .. code::
 
@@ -1388,9 +1388,9 @@ Die Paketgrößen können nun als Parameter ``piece length`` angepasst werden. D
 .. code::
 
    # Piece length (torrent file option)
-   ECELEN="524288"
+   PIECELEN="524288"
    
-Hast Du den Wert angepasst, musst Du Torrent neu startebn:
+Hast Du den Wert angepasst, musst Du Torrent neu starten:
 
 .. code::
 
@@ -1400,7 +1400,7 @@ Wurde die Option in der Konfigurationsdatei nicht explizit gesetzt, so wird ein 
 
 Mit der Erhöhung des Wertes können o.g. Probleme behoben werden.
 
-Zum Vergleich findet sich nachstehende Konfigurationsdatei ``/etc/default/linbi-torrent``:
+Zum Vergleich findet sich nachstehende Konfigurationsdatei ``/etc/default/linbo-torrent``:
 
 .. code::
 

--- a/source/clients/use_linbo4/index.rst
+++ b/source/clients/use_linbo4/index.rst
@@ -1027,7 +1027,7 @@ Auf dem Server befindet sich unter ``/etc/linuxmuster/linbo/custom_kernel.ex`` e
 
 Kopiere die Datei Vorlage ``/etc/linuxmuster/linbo/custom_kernel.ex`` nach ``/etc/linuxmuster/linbo/custom_kernel``. Editiere diese Datei nun so, dass der gewünschte Kernel auf dem Client gebootet wird. Sind in der Datei alle Zeilen auskommentiert, dann startet der Client einen letzten stable Kernel.
 
-- Es kann alternativ der **5.15er Kernel (legacy)** genutzt werden. Dazu müssen einfach in der Datei ``/etc/linuxmuster/linbo/custom_kernel`` die folgenden Zeilen eingetragen werden. Es ist nur das Kommentarzeichen für die zweite Zeile zu entfernen.
+- Es kann alternativ der **6.1er Kernel (legacy)** genutzt werden. Dazu müssen einfach in der Datei ``/etc/linuxmuster/linbo/custom_kernel`` die folgenden Zeilen eingetragen werden. Es ist nur das Kommentarzeichen für die zweite Zeile zu entfernen.
 
 .. code::
 
@@ -1132,7 +1132,7 @@ Kernel-Options verwenden
 ------------------------
 
 Auf dem Server findet sich pro Hardwareklasse eine start.conf Datei unter: ``/srv/linbo/start.conf.<Hardwareklasse>``
-Um Besonderheiten einzelner Hardwareklassen anzupassen, gibt es den Eintrag **KernelOptions_**. 
+Um Besonderheiten einzelner Hardwareklassen anzupassen, gibt es den Eintrag **KernelOptions**.
 
 .. code::
      

--- a/source/external-services/unifiwlan/index.rst
+++ b/source/external-services/unifiwlan/index.rst
@@ -7,7 +7,7 @@ Unifi-WLAN-Lösung für linuxmuster.net
 Die hier vorgestellte WLAN-Lösung spannt drei WLAN-Netze auf. 
 
 - Das interne Netz für schuleigene Geräte, wie Laptops, Beamer oder Apple-TVs. 
-- Das eigentliche Schulnetz, in dem jenach Anmelgung ins VLAN für Lehrer oder für Schüler verbunden wird.
+- Das eigentliche Schulnetz, in dem je nach Anmeldung ins VLAN für Lehrer oder für Schüler verbunden wird.
 - Das Gästenetz, in das man sich über Vouchers anmeldet. 
 
 .. figure:: media/vlantopologie.png
@@ -17,7 +17,7 @@ Es kommen Accesspoints von Unifi und der kostenlose Unifi-OS-Server zum Einsatz.
 
 Die Geräte im internen Netz werden in die Datei `/etc/linuxmuster/sophomorix/default-school/devices.csv` aufgenommen. Es ist ein Teil des Schulnetzes. Damit können sich beispielsweise Benutzer mit einem Schullaptop per WLAN wie gewohnt anmelden und auf ihre Daten zugreifen.
 
-Die folgenden Vido-Tutorials zeigen Schritt für Schritt, wie unser WLAN-Netz aufgebaut wird.
+Die folgenden Video-Tutorials zeigen Schritt für Schritt, wie unser WLAN-Netz aufgebaut wird.
 
 Überblick über den Ausgangszustand
 ----------------------------------
@@ -26,7 +26,7 @@ Die folgenden Vido-Tutorials zeigen Schritt für Schritt, wie unser WLAN-Netz au
    <iframe title="01_Ueberblick" width="560" height="315" src="https://peertube.flbcloud.de/videos/embed/78ypPvCdKd4P2Zmy9n72Hj" style="border: 0px;" allow="fullscreen" sandbox="allow-same-origin allow-scripts allow-popups allow-forms"></iframe>
 
 
-Instalation eines Debian-Servers
+Installation eines Debian-Servers
 --------------------------------
 Der Unifi-OS-Server läuft in diesem Tutorial auf einem Debian-Server. Das folgende Video-Tutorial zeigt die Installation und Integration eines leeren Debian-Servers.
 
@@ -34,7 +34,7 @@ Der Unifi-OS-Server läuft in diesem Tutorial auf einem Debian-Server. Das folge
    
    <iframe title="02_DebianServer" width="560" height="315" src="https://peertube.flbcloud.de/videos/embed/xgo1cKJFvF9YBPCUbTSYQm" style="border: 0px;" allow="fullscreen" sandbox="allow-same-origin allow-scripts allow-popups allow-forms"></iframe>  
 
-Instalation und Grundeinrichtung des Unifi-OS-Servers
+Installation und Grundeinrichtung des Unifi-OS-Servers
 -----------------------------------------------------
 Jetzt wird der eigentliche Unifi-OS-Server eingerichtet.
 
@@ -47,7 +47,7 @@ Migration eines bestehenden Unifi-Controllers
 ---------------------------------------------
 In diesem Tutorial wird gezeigt, wie ein bestehendes Unifi-Controller-System auf Unifi-OS-Server migriert werden kann.
 
-Falls du kein bestehendes Unifi-Controller-System hast, kannst du diese Tutorial übersprinen.
+Falls du kein bestehendes Unifi-Controller-System hast, kannst du dieses Tutorial überspringen.
 
 .. raw:: html
 
@@ -55,7 +55,7 @@ Falls du kein bestehendes Unifi-Controller-System hast, kannst du diese Tutorial
 
 Anlegen von Schüler- und Lehrer-Netzwerke
 -----------------------------------------
-Jetzt legen wir für die Schüler und Lehrer eigene Netzwerke auf der OpnSense an.
+Jetzt legen wir für die Schüler und Lehrer eigene Netzwerke auf der OPNsense an.
 
 .. raw:: html
 
@@ -63,7 +63,7 @@ Jetzt legen wir für die Schüler und Lehrer eigene Netzwerke auf der OpnSense a
    
 WLAN-Netzwerke im Unifi-OS-Server einrichten
 --------------------------------------------
-Hier siehst du, wie man ein WLAN über WPA2 und über WPA2/WPA3-Enterprise einrichtet. Bei WPA2/WPA3-Enterprise wird das Lehrer- bzw. Schülernetzwerk jenach Anmeldenamen zugeordnet.
+Hier siehst du, wie man ein WLAN über WPA2 und über WPA2/WPA3-Enterprise einrichtet. Bei WPA2/WPA3-Enterprise wird das Lehrer- bzw. Schülernetzwerk je nach Anmeldenamen zugeordnet.
 
 .. raw:: html
 
@@ -71,7 +71,7 @@ Hier siehst du, wie man ein WLAN über WPA2 und über WPA2/WPA3-Enterprise einri
 
 Gäste-WLAN mit Voucher
 ----------------------
-Jetzt kommet noch das Gäste-WLAN. Für Gäste und Austauschklassen legen wir noch ein Gäste-Netz an. Und wir erstellen natürlich noch Voucher die passenden Voucher.
+Jetzt kommt noch das Gäste-WLAN. Für Gäste und Austauschklassen legen wir noch ein Gäste-Netz an. Und wir erstellen natürlich noch die passenden Voucher.
 
 .. raw:: html
 
@@ -79,7 +79,7 @@ Jetzt kommet noch das Gäste-WLAN. Für Gäste und Austauschklassen legen wir no
 
 Die InnerSpace-App
 ------------------
-InnerSpace ist eine App auf dem Unifi-OS-Server, mit der man Gebäudepläne verwalten und die Position der Unifi-Komponenten entragen kann. Das ist dann besonders interessant, wenn APs oder Switche hinter Wandverschalungen verbaut sind. So weiß man immer, wo sich die Geräte befinden.
+InnerSpace ist eine App auf dem Unifi-OS-Server, mit der man Gebäudepläne verwalten und die Position der Unifi-Komponenten eintragen kann. Das ist dann besonders interessant, wenn APs oder Switche hinter Wandverschalungen verbaut sind. So weiß man immer, wo sich die Geräte befinden.
 
 Zusätzlich berechnet InnerSpace auch die aktuelle WLAN-Ausleuchtung. Man sieht also, wo noch Lücken in der Ausleuchtung sind oder ob ein anderer Ort für einen AP eine bessere WLAN-Ausleuchtung brächte.
 

--- a/source/index.rst
+++ b/source/index.rst
@@ -41,12 +41,12 @@ Neben dieser Dokumentation steht Dir unsere Community in unserem Hilfeforum und 
 
 Das Forum findest Du unter `<https://ask.linuxmuster.net>`_.
 
-Informationen zum Telefon-Support gibt es auf unser Projektseite `<https://www.linuxmuster.net/de/support-de/>`_.
+Informationen zum Telefon-Support gibt es auf unserer Projektseite `<https://www.linuxmuster.net/de/support-de/>`_.
 
 
 .. hint::
 
-   Suchst Du die Dokumentation zur Version linuxmuster.net 7.3 oder die Möglichkeit unsere Dokumentation herunterzuladen?
+   Suchst Du die Dokumentation zur Version linuxmuster.net 7.3 oder die Möglichkeit, unsere Dokumentation herunterzuladen?
 
 Dann schaue in die unten recht angezeigte - zusätzliche - Menüleiste.
 

--- a/source/installation/install-from-scratch/basis_file_server.rst
+++ b/source/installation/install-from-scratch/basis_file_server.rst
@@ -10,9 +10,9 @@ Anlegen und Installieren des Fileservers
 
 .. hint::
 
-    Der Fileserver für linuxmuster.net 7.3 kann optional installiert werden (Drei-Server-Lösung). Es kann aber weiterhin wie bisher auch ein Weiterbetrieb als Zwei-Server-Lösung erfolgen. Wir empfehlen den Fileserver z.B. in einer eigenen VM zu installieren, da hierdurch deutliche Performancesteigerungen in Verbindung mit Samba erreicht werden. Dies empfehlen wir insbesondere mittleren bis größeren Schulen. Kleinere Schulen können problemlos linuxmuster.net 7.3 als Zwei-Server-Lösung weiterbetreiben.
-    
-    Grundsätzlich kann linuxmuster.net 7.3 weiterhin als Zwei-Server-Lösung betrieben werden und es kann jederzeit später eine Erweiterung / Umstellung auf den zusätzlichen File-Server erfolgen. Die Migration/ das Update von v7.2 erfolgt zunächst immer als Zwei-Server-Lösung und es erfolgt danach eine Erweiterung um den Fileserver. 
+    Der Fileserver für linuxmuster.net 7.4 kann optional installiert werden (Drei-Server-Lösung). Es kann aber weiterhin wie bisher auch ein Weiterbetrieb als Zwei-Server-Lösung erfolgen. Wir empfehlen den Fileserver z.B. in einer eigenen VM zu installieren, da hierdurch deutliche Performancesteigerungen in Verbindung mit Samba erreicht werden. Dies empfehlen wir insbesondere mittleren bis größeren Schulen. Kleinere Schulen können problemlos linuxmuster.net 7.4 als Zwei-Server-Lösung weiterbetreiben.
+
+    Grundsätzlich kann linuxmuster.net 7.4 weiterhin als Zwei-Server-Lösung betrieben werden und es kann jederzeit später eine Erweiterung / Umstellung auf den zusätzlichen File-Server erfolgen. Die Migration/ das Update von v7.2 erfolgt zunächst immer als Zwei-Server-Lösung und es erfolgt danach eine Erweiterung um den Fileserver. 
     
 In Samba-Umgebungen ist es inzwischen üblich, den Domänencontroller und den Fileserver getrennt voneinander zu betreiben, da dies Performancevorteile hat: Selbst wenn der Fileserver auf dem gleichen Host virtualisiert wird, wie der Server und auf dem gleichen Storage läuft. Das ist für große Schulen mit vielen Clients von Vorteil.
 
@@ -165,7 +165,7 @@ Nachdem Du als Benutzer ``linuxadmin`` am file-server angemeldet bist, wechselst
 
 .. code::
 
-   sudo sh -c 'echo "deb [arch=amd64 signed-by=/usr/share/keyrings/linuxmuster.net.gpg] https://deb.linuxmuster.net/ lmn73 main" > /etc/apt/sources.list.d/lmn73.list'
+   sudo sh -c 'echo "deb [arch=amd64 signed-by=/usr/share/keyrings/linuxmuster.net.gpg] https://deb.linuxmuster.net/ lmn74 main" > /etc/apt/sources.list.d/lmn74.list'
    
 Fileserver Installation
 =======================
@@ -195,7 +195,7 @@ Weiteres Vorgehen
 
 1. Nun muss der linuxmuster.net Server (AD/DC) im nächsten Schritt vorbereitet werden.
 2. Proxmox muss in das interne Netz gebracht werden.
-3. Es muss das Setup für lmnv7.3 (AD/DC) durchgeführt werden.
+3. Es muss das Setup für lmnv7.4 (AD/DC) durchgeführt werden.
 4. Der File-Server ist in das AD einzubinden und es sind die Freigaben/Shares auf dem lmn-Server zu definieren.
 
 

--- a/source/installation/install-from-scratch/basis_file_server.rst
+++ b/source/installation/install-from-scratch/basis_file_server.rst
@@ -10,14 +10,14 @@ Anlegen und Installieren des Fileservers
 
 .. hint::
 
-    Der Fileserver für linuxmuster.net 7.3 kann optional installiert werden (Drei-Server-Lösung). Es kann aber weiterhin wie bisher auch ein Weiterbetrieb als Zwei-Server-Lösung erfolgen. Wir empfehlen den Fileserver z.B. in einer eigenen VM zu installieren, da hierdurch deutliche Performancesteigerungen in Verbidnung mit Samba erreicht werden. Dies empfehlen wir insbesondere mittleren bis grösseren Schulen. Kleinere Schulen können problemlos linuxmuster.net 7.3 als Zwei-Server-Lösung weiterbetreiben.
+    Der Fileserver für linuxmuster.net 7.3 kann optional installiert werden (Drei-Server-Lösung). Es kann aber weiterhin wie bisher auch ein Weiterbetrieb als Zwei-Server-Lösung erfolgen. Wir empfehlen den Fileserver z.B. in einer eigenen VM zu installieren, da hierdurch deutliche Performancesteigerungen in Verbindung mit Samba erreicht werden. Dies empfehlen wir insbesondere mittleren bis größeren Schulen. Kleinere Schulen können problemlos linuxmuster.net 7.3 als Zwei-Server-Lösung weiterbetreiben.
     
     Grundsätzlich kann linuxmuster.net 7.3 weiterhin als Zwei-Server-Lösung betrieben werden und es kann jederzeit später eine Erweiterung / Umstellung auf den zusätzlichen File-Server erfolgen. Die Migration/ das Update von v7.2 erfolgt zunächst immer als Zwei-Server-Lösung und es erfolgt danach eine Erweiterung um den Fileserver. 
     
 In Samba-Umgebungen ist es inzwischen üblich, den Domänencontroller und den Fileserver getrennt voneinander zu betreiben, da dies Performancevorteile hat: Selbst wenn der Fileserver auf dem gleichen Host virtualisiert wird, wie der Server und auf dem gleichen Storage läuft. Das ist für große Schulen mit vielen Clients von Vorteil.
 
 Es ist aber ohne Probleme möglich, den Fileserver später heraus zu trennen und auf eine eigene Maschine zu verlegen.
-Man kann die Umgebung also zunächst ohne extra Fileserver installieren. Stellt man später fest, dass Dateizugriffe der Nutzer zu lange dauern, kann man jederzeit den Fileserver installieren und linuxmuster.net entsprechend auf eine Dri-Server-Lösung erweitern.
+Man kann die Umgebung also zunächst ohne extra Fileserver installieren. Stellt man später fest, dass Dateizugriffe der Nutzer zu lange dauern, kann man jederzeit den Fileserver installieren und linuxmuster.net entsprechend auf eine Drei-Server-Lösung erweitern.
 
 Der Fileserver von linuxmuster.net wird vollständig in das AD des linuxmuster.net Servers integriert. Die Netzwerkfreigaben werden auf dem linuxmuster.net Server definiert und mithilfe einer DFS-Konfiguration für die konfigurierte Schule bereitgestellt. Es werden so alle persönlichen Netzlaufwerke, die Projektfreigaben, sowie die Klassenfreigaben auf diesem File-Server bereitgestellt.
 
@@ -25,7 +25,7 @@ Vorteile:
 
 - Trennung der Dienste (AD Service, File Service)
 - verbesserte Backupstrategie (jeweils eigenständiges Backup für die Dateien als auch für das AD)
-- verbesserte Sicherheit (bei einem Multi-School Setup kann jeweils ein eigenständier File-Server pro Schule eingesetzt werden.)
+- verbesserte Sicherheit (bei einem Multi-School Setup kann jeweils ein eigenständiger File-Server pro Schule eingesetzt werden.)
 - einfache Wartung und vereinfachte Updates
 - deutliche Leistungsverbesserung - gerade bei grossen Schulinstallationen
 

--- a/source/installation/install-from-scratch/basis_server.rst
+++ b/source/installation/install-from-scratch/basis_server.rst
@@ -340,7 +340,7 @@ Zum Abschluss der Installation wird automatisch versucht, Updates zu installiere
 
    Bei einer VM achte vor dem Neustart darauf, dass Du die ISO-Datei / DVD ausgeworfen hast und die Boot-Reihenfolge so umgestellt hast, dass die VM direkt von HDD bootet.
 
-Wenn die Installation abgeschlossen ist, erkennst Du daran, dass die Anzeige am unteren Bildschirmrand von
+Dass die Installation abgeschlossen ist, erkennst Du daran, dass die Anzeige am unteren Bildschirmrand von
 
 .. figure:: media/basis_server_022.png
    :align: center

--- a/source/installation/install-from-scratch/basis_server.rst
+++ b/source/installation/install-from-scratch/basis_server.rst
@@ -14,7 +14,7 @@ Anlegen und Installieren des Servers (AD/DC)
 
 .. hint::
 
-   Willst Du in einer VM installieren, so must Du für die neue VM folgende Mindesteinstellungen angeben:
+   Willst Du in einer VM installieren, so musst Du für die neue VM folgende Mindesteinstellungen angeben:
      
      - Installation von Local/ISO, 
      - Gast OS: Linux, 6.X - 2.6 Kernel
@@ -27,7 +27,7 @@ Anlegen und Installieren des Servers (AD/DC)
    Achte darauf, dass vor dem Start der VM beide Festplatten der VM zugewiesen wurden.
 
    Bei der Einrichtung des Servers musst Du nur einen Server mit 2 HDDs haben und Ubuntu auf der ersten HDD installieren.
-   Die zweite HDD bleibt wird später für linuxmuster.net genutzt.
+   Die zweite HDD wird später für linuxmuster.net genutzt.
 
 Erster Start des Servers vom Installationsmedium
 ================================================
@@ -325,7 +325,7 @@ Installiere keine weiteren optionalen Pakete.
 
 Bestätige den Start des Installationsvorganges mit ``Erledigt``.
 
-Zum Abschluß der Installation wird automatisch versucht, Updates zu installieren |...|
+Zum Abschluss der Installation wird automatisch versucht, Updates zu installieren |...|
 
 .. figure:: media/basis_server_020.png
    :align: center
@@ -340,7 +340,7 @@ Zum Abschluß der Installation wird automatisch versucht, Updates zu installiere
 
    Bei einer VM achte vor dem Neustart darauf, dass Du die ISO-Datei / DVD ausgeworfen hast und die Boot-Reihenfolge so umgestellt hast, dass die VM direkt von HDD bootet.
 
-Wann die Installation abgeschlossen ist, erkennst Du daran, dass die Anzeige am unteren Bildschirmrand von
+Wenn die Installation abgeschlossen ist, erkennst Du daran, dass die Anzeige am unteren Bildschirmrand von
 
 .. figure:: media/basis_server_022.png
    :align: center
@@ -356,7 +356,7 @@ auf
    :scale: 80%
    :alt: finished updates
 
-   ... abgeschlosse
+   ... abgeschlossen
 
 gewechselt ist.
 
@@ -513,7 +513,7 @@ Sollte die Namensauflösung Probleme bereiten, prüfe die Datei /etc/resolv.conf
 
    less /etc/resolv.conf
    
-Sollte als nameserver nur 127.0.0.53 angegeben sein, must Du diese IP durch 10.0.0.254 ersetzen.
+Sollte als nameserver nur 127.0.0.53 angegeben sein, musst Du diese IP durch 10.0.0.254 ersetzen.
 
 Test der Verbindung zur Firewall
 --------------------------------

--- a/source/installation/install-from-scratch/lmn_pre_install.rst
+++ b/source/installation/install-from-scratch/lmn_pre_install.rst
@@ -27,7 +27,7 @@ Nachdem Du nun den Server vorbereitet hast, überprüfe die Zeiteinstellungen au
    timedatectl
    
 Es wird hier noch die UTC-Zeit angegeben. Wie für die OPNsense muss nun die Zeitzone angepasst werden.
-Die erfolgt mit folgendem Befehl:
+Dies erfolgt mit folgendem Befehl:
 
 .. code-block:: Bash
 
@@ -35,7 +35,7 @@ Die erfolgt mit folgendem Befehl:
    # erneute Ausgabe der Zeiteinstellungen mit
    timedatectl
    
-Du solltest nun als Zeitzone ``Europe/Berlin`` und die korrekte Lokalzeit sowie die korrkte UTC - Zeit angezeigt bekommen.
+Du solltest nun als Zeitzone ``Europe/Berlin`` und die korrekte Lokalzeit sowie die korrekte UTC-Zeit angezeigt bekommen.
  
  
 Cloud-init deinstallieren
@@ -46,7 +46,7 @@ Cloud-init kannst Du unter Ubuntu mit folgenden Schritten löschen:
 .. code-block:: Bash
 
    # Disable start
-   # Sollte die Datei schon existieren mit dem nächsten Schritt forfahren - sudo apt purge cloud-init -y
+   # Sollte die Datei schon existieren mit dem nächsten Schritt fortfahren - sudo apt purge cloud-init -y
    sudo touch /etc/cloud/cloud-init.disabled
 
    # Uninstall
@@ -118,7 +118,7 @@ Erzeuge nun die Locales neu:
    de_DE.UTF-8... done
    Generation complete.
 
-Du kannst die Default-Locale ggf. auch mit folgenden Befehl neu setzen:
+Du kannst die Default-Locale ggf. auch mit folgendem Befehl neu setzen:
 
 .. code-block:: Bash
 
@@ -181,14 +181,14 @@ Wenn Du nicht mehr an Deinem Server eingeloggt bist, melde Dich erneut an.
    sr0     11:0    1 1024M  0 rom  
 
 In o.g. Beispiel wurde Ubuntu Server auf der 1. Festplatte (sda) installiert. Die erste Partition der ersten Platte wird für EFI verwendet,
-auf der zweiten Partition wird die Root-Partition ( / ) eingehangen. Auf der zweiten Platte existiert eine PArtition, die auf /srv eingehangen ist.
+auf der zweiten Partition wird die Root-Partition ( / ) eingehangen. Auf der zweiten Platte existiert eine Partition, die auf /srv eingehangen ist.
 
 Skript herunterladen
 --------------------
 
 Führe danach folgende Befehle in der Eingabekonsole aus:
 
-Wechsel Deinen Log-in und werde zu ``root``, falls du es nicht mehr sein solltest:
+Wechsle Deinen Log-in und werde zu ``root``, falls du es nicht mehr sein solltest:
 
 .. code-block:: Bash
  
@@ -226,7 +226,7 @@ Mit dem Parametern -u (unattended) und -p (Serverprofil) wird das Setup für den
 Ablauf
 ======
 
-Es werden alle erforderliche Pakete geladen und installiert. Dies kann etwas dauern. Nach Abschluss des Installations- und Vorbereitungsarbeiten wirst Du aufgefordert, den Server neu zu starten.
+Es werden alle erforderlichen Pakete geladen und installiert. Dies kann etwas dauern. Nach Abschluss des Installations- und Vorbereitungsarbeiten wirst Du aufgefordert, den Server neu zu starten.
 
 .. code-block:: Bash
 

--- a/source/installation/install-from-scratch/lmn_pre_install.rst
+++ b/source/installation/install-from-scratch/lmn_pre_install.rst
@@ -3,7 +3,7 @@
 .. _lmn_pre_install-label:
 
 =====================================
-Server (AD/DC) auf lmn7.3 vorbereiten
+Server (AD/DC) auf lmn7.4 vorbereiten
 =====================================
 
 .. sectionauthor:: `@cweikl <https://ask.linuxmuster.net/u/cweikl>`_
@@ -181,7 +181,7 @@ Wenn Du nicht mehr an Deinem Server eingeloggt bist, melde Dich erneut an.
    sr0     11:0    1 1024M  0 rom  
 
 In o.g. Beispiel wurde Ubuntu Server auf der 1. Festplatte (sda) installiert. Die erste Partition der ersten Platte wird für EFI verwendet,
-auf der zweiten Partition wird die Root-Partition ( / ) eingehangen. Auf der zweiten Platte existiert eine Partition, die auf /srv eingehangen ist.
+auf der zweiten Partition wird die Root-Partition ( / ) eingehängt. Auf der zweiten Platte existiert eine Partition, die auf /srv eingehängt ist.
 
 Skript herunterladen
 --------------------
@@ -254,7 +254,7 @@ Ist lmn-appliance ohne Fehler durchgelaufen, starte danach den Server neu mit de
 
   reboot
 
-Danach steht dem Setup v7.3 nichts mehr im Wege.
+Danach steht dem Setup v7.4 nichts mehr im Wege.
 
 Paketquellen eintragen
 ======================
@@ -263,7 +263,7 @@ Paketquellen eintragen
 
    Dies muss nur ausgeführt werden, sofern Du den Server bzw. die VM nicht mit dem Skript ``lmn-appliance`` vorbereitet haben solltest.
 
-Es müssen für linuxmuster.net v7.3 die neuen Paketquellen eingetragen werden.
+Es müssen für linuxmuster.net v7.4 die neuen Paketquellen eingetragen werden.
 
 Zur Eintragung der Paketquellen führe folgende Befehle in der Eingabekonsole aus:
 
@@ -275,11 +275,11 @@ Zur Eintragung der Paketquellen führe folgende Befehle in der Eingabekonsole au
 
 Damit installierst Du den Key für das Repository von linuxmuster.net und aktivierst ihn.
 
-Füge dann das Linuxmuster 7.3 Repository hinzu.
+Füge dann das Linuxmuster 7.4 Repository hinzu.
 
 .. code-block:: Bash
 
-   sudo sh -c 'echo "deb [arch=amd64 signed-by=/usr/share/keyrings/linuxmuster.net.gpg] https://deb.linuxmuster.net/ lmn73 main" > /etc/apt/sources.list.d/lmn.list'
+   sudo sh -c 'echo "deb [arch=amd64 signed-by=/usr/share/keyrings/linuxmuster.net.gpg] https://deb.linuxmuster.net/ lmn74 main" > /etc/apt/sources.list.d/lmn.list'
 
 Aktualisiere die Softwareliste des Servers:
 

--- a/source/installation/proxmox/index.rst
+++ b/source/installation/proxmox/index.rst
@@ -30,7 +30,7 @@ Systemvoraussetzungen
 
 In der unten aufgeführten Tabelle findest Du die Systemvoraussetzungen zum Betrieb der virtuellen Maschinen. Die Systemanforderungen für die Installation von Proxmox selbst finden sich im Web unter https://www.proxmox.com/de/proxmox-ve/systemanforderungen. 
 
-Die Werte bilden die Mindestvoraussetzungen zur Planung. Für die Installation mit Proxmox und linuxmuster v7.3 wird als Standard der ``IP-Bereich 10.0.0.0/16`` genutzt.
+Die Werte bilden die Mindestvoraussetzungen zur Planung. Für die Installation mit Proxmox und linuxmuster v7.4 wird als Standard der ``IP-Bereich 10.0.0.0/16`` genutzt.
 
 ============ ============= ================= =====
 VM           IP            HDD               RAM 
@@ -666,7 +666,7 @@ Hier noch der Vollständigkeitshalber die schematische Darstellung, wie sie sich
 Vorbereiten des ISO-Speichers
 =============================
 
-Um die v7.3 zu installieren, müssen zwei virtuelle Maschinen angelegt werden. OPNsense und Ubuntu Server LTS werden in diesen VMs installiert. Dazu ist es erforderlich, dass Du die ISO-Images für OPNsense und Ubuntu Server LTS auf den Proxmox-Hypervisor in den Datenspeicher für ISO-Images lädst.
+Um die v7.4 zu installieren, müssen zwei virtuelle Maschinen angelegt werden. OPNsense und Ubuntu Server LTS werden in diesen VMs installiert. Dazu ist es erforderlich, dass Du die ISO-Images für OPNsense und Ubuntu Server LTS auf den Proxmox-Hypervisor in den Datenspeicher für ISO-Images lädst.
 
 .. figure:: media/proxmox-download-iso_01.png
    :align: center
@@ -1006,7 +1006,7 @@ Klicke auf ``Add``.
 Anlegen der VM für linuxmuster server
 -------------------------------------
 
-Um für den linuxmuster.net Server v7.3 die VM anzulegen, wählst Du erneut in der Proxmox - Verwaltungsoberfläche den Button ``Create VM``.
+Um für den linuxmuster.net Server v7.4 die VM anzulegen, wählst Du erneut in der Proxmox - Verwaltungsoberfläche den Button ``Create VM``.
 
 .. figure:: media/proxmox-create-vm.png
    :align: center
@@ -1249,4 +1249,4 @@ Die beiden letzten Einstellungen musst Du **nochmals für den linuxmuster.net AD
 
 Die virtuellen Maschinen sind jetzt für die weitere Installation vorbereitet. Du kannst gemäß der Anleitung: :ref:`first_start_firewall` mit der Installation fortfahren.
 
-.. hint:: Jetzt wäre auch ein guter Zeitpunkt für ein Snapshoting und/oder dem Klonen der bisher erstellten VMs. 
+.. hint:: Jetzt wäre auch ein guter Zeitpunkt für einen Snapshot und/oder das Klonen der bisher erstellten VMs. 

--- a/source/installation/proxmox/index.rst
+++ b/source/installation/proxmox/index.rst
@@ -85,7 +85,7 @@ Lade Dir dort das aktuellste Image herunter und erstelle Dir einen bootfähigen 
 Erstellen eines USB-Sticks zur Installation des Proxmox-Host
 ------------------------------------------------------------
 
-Nachdem Du die ISO-Datei für Proxmox heruntergeladen hast, wechselst Du in das Download-Verzeichnis. Danach ermittel Du den korrekten Buchstaben für den USB-Stick unter Linux. Das X bei sdX ist durch den korrekten Buchstaben für den USB-Stick zu ersetzen (z.B. /dev/sda). Nachstehender Befehl als Benutzer *root* oder mit einem *sudo* vorangestellt einzugeben:
+Nachdem Du die ISO-Datei für Proxmox heruntergeladen hast, wechselst Du in das Download-Verzeichnis. Danach ermittelst Du den korrekten Buchstaben für den USB-Stick unter Linux. Das X bei sdX ist durch den korrekten Buchstaben für den USB-Stick zu ersetzen (z.B. /dev/sda). Nachstehender Befehl ist als Benutzer *root* oder mit einem vorangestellten *sudo* einzugeben:
 
 .. code-block:: console
 
@@ -109,7 +109,7 @@ Um zu Beginn den Proxmox-Host zu administrieren, ist ein Laptop/PC mit dem Switc
    Aufbau des Netzwerkes zur Proxmox Installation
 
 
-Es werden zunächst alle Aktualisierungen durchgeführt und die benötigten ISO-Images auf den Proxmox-Host heruntergeladen. Erst danach wird die Konfiguration des Proxmox-Host so geändert wird, dass dieser nur noch im grünen Netz erreichbar ist.
+Es werden zunächst alle Aktualisierungen durchgeführt und die benötigten ISO-Images auf den Proxmox-Host heruntergeladen. Erst danach wird die Konfiguration des Proxmox-Host so geändert, dass dieser nur noch im grünen Netz erreichbar ist.
 
 
 Installieren von Proxmox
@@ -183,7 +183,7 @@ Hier wurde die interne IP-Adresse `192.168.199.20/24` festgelegt.
    :scale: 60%
    :alt: Proxmox Installation Netzwerk Konfiguration
 
-   Netwerk Konfiguration
+   Netzwerk Konfiguration
 
 Überprüfe auf der Übersichtsseite, dass alle Angaben korrekt sind und fahre anschließend fort.
 
@@ -192,7 +192,7 @@ Hier wurde die interne IP-Adresse `192.168.199.20/24` festgelegt.
    :scale: 40%
    :alt: Proxmox Installation Übersicht
 
-   Zusamenfassung der Installationsoptionen
+   Zusammenfassung der Installationsoptionen
 
 Warte den Abschluss der Installation ab.
 
@@ -252,9 +252,9 @@ Kommentiere zuerst die Paketquellen für die Enterprise-Pakete aus, die nach der
 
 .. hint:
 
-   Falls Du die beiden Befehl via copy&paste übernimmst, prüfe, ob in der Eingabekonsole die Hochkommata erhalten bleiben.
+   Falls Du die beiden Befehle via copy&paste übernimmst, prüfe, ob in der Eingabekonsole die Hochkommata erhalten bleiben.
 
-Füge dann für Proxmox VE eine neu Paketquelle für die No-Subscription-Pakete hinzu.
+Füge dann für Proxmox VE eine neue Paketquelle für die No-Subscription-Pakete hinzu.
 
 .. code::
 
@@ -666,7 +666,7 @@ Hier noch der Vollständigkeitshalber die schematische Darstellung, wie sie sich
 Vorbereiten des ISO-Speichers
 =============================
 
-Um die v7.3 zu installieren, müssen zwei virtuelle Maschinen angelegt werden. OPNsense und Ubuntu Server LTS werden in diesei VMs installiert. Dazu ist es erforderlich, dass Du die ISO-Images für OPNsense und Ubuntu Server LTS auf den Proxmox-Hypervisor in den Datenspeicher für ISO-Images lädst.
+Um die v7.3 zu installieren, müssen zwei virtuelle Maschinen angelegt werden. OPNsense und Ubuntu Server LTS werden in diesen VMs installiert. Dazu ist es erforderlich, dass Du die ISO-Images für OPNsense und Ubuntu Server LTS auf den Proxmox-Hypervisor in den Datenspeicher für ISO-Images lädst.
 
 .. figure:: media/proxmox-download-iso_01.png
    :align: center
@@ -682,7 +682,7 @@ Ubuntu Server
 
 .. hint:: 
 
-   Beachte für den Download des Ubuntu Servers, dass du immer die Version verwendest, die in den Systemvoraussetzungen genannt wurde.
+   Beachte für den Download des Ubuntu Servers, dass Du immer die Version verwendest, die in den Systemvoraussetzungen genannt wurde.
 
    Bei den Bildern wird ggf. noch eine abweichende Version gezeigt. Diese ist unbedingt anzupassen.
 
@@ -1040,7 +1040,7 @@ Klicke dann auf ``Next``.
 
 Belasse hier zunächst alle Voreinstellungen für Grafikkarte und Festplatten-Controller wie angezeigt.
 Wähle als BIOS ``OVMF (UEFI)`` und füge einen EFI-Storage hinzu. Wähle hier im Drop-down den zuvor eingerichteten Proxmox-Speicher aus.
-Aktiviere den ``Qmu Agent``.
+Aktiviere den ``Qemu Agent``.
 
 .. figure:: media/proxmox-create-vm-ubuntu-server-03.png
    :align: center
@@ -1249,4 +1249,4 @@ Die beiden letzten Einstellungen musst Du **nochmals für den linuxmuster.net AD
 
 Die virtuellen Maschinen sind jetzt für die weitere Installation vorbereitet. Du kannst gemäß der Anleitung: :ref:`first_start_firewall` mit der Installation fortfahren.
 
-.. hint:: Jetzt wäre auch ein guter Zeitpunkt für ein Snapshoting und/oder dem Klonen der bisher erstellen VMs. 
+.. hint:: Jetzt wäre auch ein guter Zeitpunkt für ein Snapshoting und/oder dem Klonen der bisher erstellten VMs. 

--- a/source/migration/index.rst
+++ b/source/migration/index.rst
@@ -6,7 +6,7 @@
  Migration auf linuxmuster 7.4
 ===============================
 
-.. sectionauthor:: `@cweikl <https://ask.linuxmuster,net/u/cweikl>`_ 
+.. sectionauthor:: `@cweikl <https://ask.linuxmuster.net/u/cweikl>`_
 
 
 Um auf die linuxmuster 7.4 zu migrieren:

--- a/source/migration/upgrade.rst
+++ b/source/migration/upgrade.rst
@@ -51,7 +51,7 @@ Rufe das Skript wie folgt auf:
 
    Falls Du Dich via SSH auf dem Server anmeldest, stelle sicher, dass Du als user ``root`` eine tmux-Session startest, damit das Upgrade nicht die SSH-Verbindung unterbricht.
 
-Das Upgrade dauert eine ganze Zeit. Du erhälst zu Beginn auf der Konsole den Hinweis, dass Du vor dem Upgrade einen Snapshot Deiner VM anlegen solltest. Zum Start des Upgrades musst Du dann den in der Konsole angezeigten Text eingeben und dies mit ENTER bestätigen. Danach startet das Upgrade.
+Das Upgrade dauert eine ganze Zeit. Du erhältst zu Beginn auf der Konsole den Hinweis, dass Du vor dem Upgrade einen Snapshot Deiner VM anlegen solltest. Zum Start des Upgrades musst Du dann den in der Konsole angezeigten Text eingeben und dies mit ENTER bestätigen. Danach startet das Upgrade.
 
 Prüfe während des Upgrades, ob Fehler ausgegeben werden. Im Nachgang kannst Du zudem in der mitgeschriebenen Log-Datei ggf. nach Fehlern suchen.
 

--- a/source/setup/setup-file-server.rst
+++ b/source/setup/setup-file-server.rst
@@ -10,7 +10,7 @@ Setup File-Server
               
 .. hint::
 
-    Der Fileserver für inuxmuster.net 7.3 kann optional installiert werden (Drei-Server-Lösung). Es kann aber weiterhin wie bisher auch ein Weiterbetrieb als Zwei-Server-Lösung erfolgen. Wir empfehlen den Fileserver z.B. in einer eigenen VM zu installieren, da hierdurch deutliche Performancesteigerungen in Verbidnung mit Samba erreicht werden. Dies empfehlen wir insbesondere mittleren bis grösseren Schulen. Kleinere Schulen können problemlos linuxmuster.net 7.3 als Zwei-Server-Lösung weiterbetreiben.
+    Der Fileserver für linuxmuster.net 7.3 kann optional installiert werden (Drei-Server-Lösung). Es kann aber weiterhin wie bisher auch ein Weiterbetrieb als Zwei-Server-Lösung erfolgen. Wir empfehlen den Fileserver z.B. in einer eigenen VM zu installieren, da hierdurch deutliche Performancesteigerungen in Verbindung mit Samba erreicht werden. Dies empfehlen wir insbesondere mittleren bis größeren Schulen. Kleinere Schulen können problemlos linuxmuster.net 7.3 als Zwei-Server-Lösung weiterbetreiben.
     
     Grundsätzlich kann linuxmuster.net 7.3 weiterhin als Zwei-Server-Lösung betrieben werden und es kann jederzeit später eine Erweiterung / Umstellung auf den zusätzlichen File-Server erfolgen. Die Migration/ das Update von v7.2 erfolgt zunächst immer als Zwei-Server-Lösung und es erfolgt danach eine Erweiterung um den Fileserver.                
 
@@ -138,7 +138,7 @@ d) Schulname: wird -s ausgelassen, wird default-school genutzt
 
 .. hint::
 
-   Hast Du zuvor das Setup des linuxmuster.net AD/DC Server durchlaufen, dann nutzt Du dort den Share default-school - unabhängig davon, wie Du beim Setup Deine Schule genannt hast. Du must also für den File-Server daher diese angeben bzw. den Parameter -s weglassen.
+   Hast Du zuvor das Setup des linuxmuster.net AD/DC Server durchlaufen, dann nutzt Du dort den Share default-school - unabhängig davon, wie Du beim Setup Deine Schule genannt hast. Du musst also für den File-Server daher diese angeben bzw. den Parameter -s weglassen.
 
 .. code::
 
@@ -151,7 +151,7 @@ Wurde das Setup erfolgreich ausgeführt, siehst Du folgende Bestätigung:
    :alt: successful setup
    :width: 40%
    
-   File-Server: Erolgreiches Setup
+   File-Server: Erfolgreiches Setup
    
 Auf dem File-Server findet sich nun das Verzeichnis:
 
@@ -226,7 +226,7 @@ Gib im Terminal zur Aktualisierung der Freigaben (Shares) folgende Befehle ein:
 
 .. hint::
 
-   Hast Du für den File-Server einen anderen Schulnamen als den Vorgabewert (default-school) angegeben, dann must Du diesen hier angeben.
+   Hast Du für den File-Server einen anderen Schulnamen als den Vorgabewert (default-school) angegeben, dann musst Du diesen hier angeben.
    
 .. attention::
 

--- a/source/setup/setup-file-server.rst
+++ b/source/setup/setup-file-server.rst
@@ -10,9 +10,9 @@ Setup File-Server
               
 .. hint::
 
-    Der Fileserver für linuxmuster.net 7.3 kann optional installiert werden (Drei-Server-Lösung). Es kann aber weiterhin wie bisher auch ein Weiterbetrieb als Zwei-Server-Lösung erfolgen. Wir empfehlen den Fileserver z.B. in einer eigenen VM zu installieren, da hierdurch deutliche Performancesteigerungen in Verbindung mit Samba erreicht werden. Dies empfehlen wir insbesondere mittleren bis größeren Schulen. Kleinere Schulen können problemlos linuxmuster.net 7.3 als Zwei-Server-Lösung weiterbetreiben.
-    
-    Grundsätzlich kann linuxmuster.net 7.3 weiterhin als Zwei-Server-Lösung betrieben werden und es kann jederzeit später eine Erweiterung / Umstellung auf den zusätzlichen File-Server erfolgen. Die Migration/ das Update von v7.2 erfolgt zunächst immer als Zwei-Server-Lösung und es erfolgt danach eine Erweiterung um den Fileserver.                
+    Der Fileserver für linuxmuster.net 7.4 kann optional installiert werden (Drei-Server-Lösung). Es kann aber weiterhin wie bisher auch ein Weiterbetrieb als Zwei-Server-Lösung erfolgen. Wir empfehlen den Fileserver z.B. in einer eigenen VM zu installieren, da hierdurch deutliche Performancesteigerungen in Verbindung mit Samba erreicht werden. Dies empfehlen wir insbesondere mittleren bis größeren Schulen. Kleinere Schulen können problemlos linuxmuster.net 7.4 als Zwei-Server-Lösung weiterbetreiben.
+
+    Grundsätzlich kann linuxmuster.net 7.4 weiterhin als Zwei-Server-Lösung betrieben werden und es kann jederzeit später eine Erweiterung / Umstellung auf den zusätzlichen File-Server erfolgen. Die Migration/ das Update von v7.2 erfolgt zunächst immer als Zwei-Server-Lösung und es erfolgt danach eine Erweiterung um den Fileserver.                
 
 File-Server aufnehmen
 =====================
@@ -25,7 +25,7 @@ Melde Dich als Benutzer ``linuxadmin`` mit dem Passwort ``Muster!`` auf dem linu
 
 Für diese Anmeldung kannst Du die xterm.js Konsole von Proxmox verwenden, wenn Du unserer Anleitung gefolgt bist. Alternativ kannst Du Dich via ssh von einem anderen Rechner mit dem Server verbinden, wenn er sich im gleichen Netzwerksegment befindet.
 
-Im Terminal wirst Du mit dem Erstbildschirm von linuxmuster.net v7.3 begrüßt und es werden die installierten Paketversionen von linuxmuster.net angezeigt.
+Im Terminal wirst Du mit dem Erstbildschirm von linuxmuster.net v7.4 begrüßt und es werden die installierten Paketversionen von linuxmuster.net angezeigt.
 
 .. figure:: media/newsetup/lmn-setup-terminal-01.png
    :align: center
@@ -230,7 +230,7 @@ Gib im Terminal zur Aktualisierung der Freigaben (Shares) folgende Befehle ein:
    
 .. attention::
 
-   Nachstehenden Befehl musst Du nur eingeben, wenn Du eine neue Installation von linuxmuster.net zusammen mit dem Fileserver durchführst. Hast Du bereits eine lmn v7.3 installiert / eingerichtet und fügst erst später den Fileserver hinzu, dann musst Du folgenden Befehl weglassen: ``net conf addshare $SCHOOL /srv/samba/schools/$SCHOOL/``
+   Nachstehenden Befehl musst Du nur eingeben, wenn Du eine neue Installation von linuxmuster.net zusammen mit dem Fileserver durchführst. Hast Du bereits eine lmn v7.4 installiert / eingerichtet und fügst erst später den Fileserver hinzu, dann musst Du folgenden Befehl weglassen: ``net conf addshare $SCHOOL /srv/samba/schools/$SCHOOL/``
 
 .. code::
 

--- a/source/setup/setup.rst
+++ b/source/setup/setup.rst
@@ -32,7 +32,7 @@ Wichtige Hinweise
   - für das Setup von linuxmuster benötigst Du nun eine Subdomain, die vom AD DNS-Server authoritativ intern aufgelöst wird, aber niemals von extern.
   - der AD DNS-Server arbeitet immer nur für diese eine Subdomain und die darunter liegenden Namensräume autoritativ.
   - alle internen Clients müssen den AD DNS-Server als DNS-Server nutzen.
-  - diese Subdomain darf nicht nicht länger als 15 Zeichen sein (NetBIOS-Name) und keine Satzzeichen enthalten.
+  - diese Subdomain darf nicht länger als 15 Zeichen sein (NetBIOS-Name) und keine Satzzeichen enthalten.
   - der Fully Qualified Domain Name (FQDN) darf nicht länger als 64 Byte sein.
   - nutze niemals nicht registrierte Domains wie z.B. .local -> meineschule.local 
 

--- a/source/systemadministration/network/radius/index.rst
+++ b/source/systemadministration/network/radius/index.rst
@@ -13,7 +13,7 @@ RADIUS (Remote Authentification Dial-In User Service) ist ein Client-Server Prot
 für das Accounting (Triple A - AAA) von Benutzern in einem Netzwerk dient.
 
 Der RADIUS-Server dient als zentraler Authentifizierungsserver, an den sich verschiedene IT-Dienste für die Authentifizierung wenden 
-können. RADIUS bietet sich an, um in grossen Netzen sicherzustellen, dass ausschließlich berechtigte Nutzer Zugriff haben. 
+können. RADIUS bietet sich an, um in großen Netzen sicherzustellen, dass ausschließlich berechtigte Nutzer Zugriff haben.
 Der Zugriff kann zudem auch auf bestimmte Endgeräte beschränkt werden. 
 Um die Authentifizierungsdaten zu übertragen, wird oftmals das Protokoll EAP (Extensible Authentification Protocol) genutzt.
 
@@ -71,7 +71,7 @@ Wenn Du z.B. nur die Gruppe der Lehrer und der Schüler der Oberstufenklassen �
 
    server ~ # sophomorix-managementgroup --set-wifi teachers_and_oberstufe
 
-Um noch weitere einzelne Schüler hinzuzunehmen oder zu entfernen, nutzt Du danach die Funktion --wifi bzw. --nowifi mit von Komma getrennten Benutzernamen.
+Um noch weitere einzelne Schüler hinzuzunehmen oder zu entfernen, nutzt Du danach die Funktion --wifi bzw. --nowifi mit von Kommas getrennten Benutzernamen.
 
 .. code::
 
@@ -110,14 +110,14 @@ Danach muss der samba-ad-dc Dienst neu gestartet werden:
 Radius konfigurieren
 ^^^^^^^^^^^^^^^^^^^^
 
-Dem Freeradius-Dient muss Zugriff auf winbind gegeben werden:
+Dem Freeradius-Dienst muss Zugriff auf winbind gegeben werden:
 
 .. code::
 
    usermod -a -G winbindd_priv freerad
    chown root:winbindd_priv /var/lib/samba/winbindd_privileged/
 
-In dem Verzeichnis ``/etc/freeradius/3.0/sites-enabled`` in die Dateien ``default`` und ``inner-tunnel`` ganz am Anfang unter ``authenticate`` ist ``ntlm_auth`` einzufügen.
+In dem Verzeichnis ``/etc/freeradius/3.0/sites-enabled`` in den Dateien ``default`` und ``inner-tunnel`` ganz am Anfang unter ``authenticate`` ist ``ntlm_auth`` einzufügen.
 
 .. code::
 
@@ -141,7 +141,7 @@ Anpassen des Abschnitts ``ntlm_auth`` weiter unten. Zuerst das Kommentarzeichen 
    # eine Zeile
    ntlm_auth = "/usr/bin/ntlm_auth --allow-mschapv2 --request-nt-key --domain=DOMÄNE --require-membership-of=DOMÄNE\\wifi --username=%{%{Stripped-User-Name}:-%{%{User-Name}:-None}} --challenge=%{%{mschap:Challenge}:-00} --nt-response=%{%{mschap:NT-Response}:-00}"
 
-Dabei muss DOMÄNE durch den eigenen Domänennamen ersetzt werden. Gebe den Inhalt der Datei ``/etc/hosts`` mit folgendem Befehl aus:
+Dabei muss DOMÄNE durch den eigenen Domänennamen ersetzt werden. Gib den Inhalt der Datei ``/etc/hosts`` mit folgendem Befehl aus:
 
 
 .. code::
@@ -198,7 +198,7 @@ Um alle Schüler aus der Gruppe wifi zu nehmen, listest Du alle User des Systems
 
    samba-tool user list > user.txt
 
-Jetzt entferns Du alle User aus der Liste, die immer ins Wlan dürfen sollen. Danach baust Du die Liste zu einer Kommazeile um mit:
+Jetzt entfernst Du alle User aus der Liste, die immer ins Wlan dürfen sollen. Danach baust Du die Liste zu einer Kommazeile um mit:
 
 .. code::
 
@@ -248,7 +248,7 @@ Danach ist ein neues Zertifikat zu beantragen:
 
     openssl req -new -key radius-key.pem -out radius.csr -sha512
 
-Gebe hierbei die gewünschten Informationen an. Bei ``Common Name (e.g. server FQDN or YOUR name) []:`` muss die zuvor ermittelte CN eingetragen werden, die z.B. durch ein vorangestelltes ``radius`` ergänzt wird. Ein korrekter Eintrag wäre z.B.: ``radius.gshoenningen.linuxmuster.lan``
+Gib hierbei die gewünschten Informationen an. Bei ``Common Name (e.g. server FQDN or YOUR name) []:`` muss die zuvor ermittelte CN eingetragen werden, die z.B. durch ein vorangestelltes ``radius`` ergänzt wird. Ein korrekter Eintrag wäre z.B.: ``radius.gshoenningen.linuxmuster.lan``
 
 Das Zertifikat ist nun noch auszustellen. Zuvor wird noch das Kennwort für den CA-Key (/etc/linuxmuster/ssl/cakey.pem) benötigt. Das Kennwort findet sich unter ``/etc/linuxmuster/.secret/cakey``.
 
@@ -299,7 +299,7 @@ Passe nun RADIUS so an, dass das Fullchain-Zertifikat genutzt wird.
 
 .. hint::
 
-   Je nach Server-Distribution ist ggf. die datei EAP unter /etc/raddb/mods-enabled/eap oder je nach Radius-Version unter /etc/freeradius/3.2/mods-enabled/eap anzupassen.
+   Je nach Server-Distribution ist ggf. die Datei EAP unter /etc/raddb/mods-enabled/eap oder je nach Radius-Version unter /etc/freeradius/3.2/mods-enabled/eap anzupassen.
 
 Danach den Dienst neu starten:
 
@@ -316,7 +316,7 @@ Auf diese Weise kann WPA-Enterprise auch mit neueren Client-Betriebssystemen gen
 Firewallregeln anpassen
 ^^^^^^^^^^^^^^^^^^^^^^^
 
-Auf der Firewall OPNsense® muss je nach eigenen Voraussetzungen dafür gesorgt werden, dass die AP’s aus dem Wlan-Netz den Server auf dem Port 1812 via udp erreichen können. Es ist darauf zu achten, dass die IP des Servers den eigenen Netzvorgaben entspricht (also z.B. 10.0.0.1/16 oder /24 oder 10.16.1.1/16 oder /24)
+Auf der Firewall OPNsense® muss je nach eigenen Voraussetzungen dafür gesorgt werden, dass die APs aus dem Wlan-Netz den Server auf dem Port 1812 via UDP erreichen können. Es ist darauf zu achten, dass die IP des Servers den eigenen Netzvorgaben entspricht (also z.B. 10.0.0.1/16 oder /24 oder 10.16.1.1/16 oder /24)
 
 Die Regel auf der OPNsense® hierzu könnte, wie nachstehend abgebildet, eingetragen werden.
 
@@ -426,7 +426,7 @@ Nachdem der LDAP-Zugriff konfiguriert ist, muss nur noch die gruppenabhängige V
         Tunnel-Type :=VLAN,
         Tunnel-Medium-Type:=6,
         Tunnel-Private-Group-Id := 20,
-        Reply-Message := "Wilkommen im Lehrer-WLAN"
+        Reply-Message := "Willkommen im Lehrer-WLAN"
         }
       }
     else{
@@ -434,7 +434,7 @@ Nachdem der LDAP-Zugriff konfiguriert ist, muss nur noch die gruppenabhängige V
         Tunnel-Type :=VLAN,
         Tunnel-Medium-Type:=6,
         Tunnel-Private-Group-Id := 10,
-        Reply-Message := "Wilkommen im Schüler-WLAN"
+        Reply-Message := "Willkommen im Schüler-WLAN"
       }
     }
 
@@ -456,7 +456,7 @@ So wird der RADIUS getestet:
 	Tunnel-Type:0 = VLAN
 	Tunnel-Medium-Type:0 = IEEE-802
 	Tunnel-Private-Group-Id:0 = "20"
-	Reply-Message = "Wilkommen im Lehrer-WLAN"
+	Reply-Message = "Willkommen im Lehrer-WLAN"
 	
 oder mit Schülerzugangsdaten
 
@@ -475,13 +475,13 @@ oder mit Schülerzugangsdaten
 	Tunnel-Type:0 = VLAN
 	Tunnel-Medium-Type:0 = IEEE-802
 	Tunnel-Private-Group-Id:0 = "10"
-	Reply-Message = "Wilkommen im Schüler-WLAN"
+	Reply-Message = "Willkommen im Schüler-WLAN"
 	
 
 VLANs im Unifi-Controller nutzen
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Die VLAN-Zurodnung lässt sich jetzt sehr einfach im Unifi-Controller nutzen.
+Die VLAN-Zuordnung lässt sich jetzt sehr einfach im Unifi-Controller nutzen.
 
 Die VLANs müssen natürlich auch als Netzwerk im Unifi-Controller definiert sein. Unter **Einstellungen -> Netzwerke** lassen sich die Netzwerke einfach definieren. 
 

--- a/source/systemadministration/printer/configure-ad-group.rst
+++ b/source/systemadministration/printer/configure-ad-group.rst
@@ -8,7 +8,7 @@ Drucker einzelnen Räumen zuweisen
 
 Die Zuordnung der Drucker auf die Räume wird mit Hilfe der Schulkonsole gemacht.
 
-Melde dich dazu als ``global-admin an`` der Schulkonsole an und gehe unter Klassenzimmer auf Einschreiben.
+Melde dich dazu als ``global-admin`` an der Schulkonsole an und gehe unter Klassenzimmer auf Einschreiben.
 
 .. image:: media/configure-ad-group_01.png
    :alt: Schulkonsole Klassenzimmer Einschreiben
@@ -32,7 +32,7 @@ Gib den Namen des Raums, dem der Drucker zugewiesen werden soll, ein und bestät
    :alt: Schulkonsole Klassenzimmer Einschreiben physiklaser1
    :align: center
 
-Danach sollten die Raumnamen, denen der Drucker zugewiesn ist unter Gruppen aufgeführt sein. Natürlich kann man einen Drucker auch zwei Räumen zuweisen. Das macht dann Sinn, wenn sich mehrere Räume einen Drucker teilen. 
+Danach sollten die Raumnamen, denen der Drucker zugewiesen ist unter Gruppen aufgeführt sein. Natürlich kann man einen Drucker auch zwei Räumen zuweisen. Das macht dann Sinn, wenn sich mehrere Räume einen Drucker teilen. 
 
 Alle Rechner, die im Physikraum stehen, werden ab „jetzt“ Zugriff auf den PhysikLaser1 haben.
 Allerdings kann es eine ganze Weile dauern, bis sich dieser Eintrag auf die Druckerverteilung auswirkt. Starte am besten Deinen Client neu.


### PR DESCRIPTION
## Summary
Rechtschreib-/Grammatikprüfung der seit v7.3 geänderten Kapitel (Delta-Review, keine Vollprüfung der gesamten Doku). Enthält u. a.:

- Zahlreiche Tippfehler (z. B. "Vido-Tutorials" → "Video-Tutorials", "Instalation" → "Installation", "Wilkommen" → "Willkommen")
- Verbkonjugation/Adjektivendungen (z. B. "must Du" → "musst Du", "erhälst" → "erhältst", "grosse"/"grosser" → "große"/"großer")
- Ein defekter Link in `migration/index.rst` (Komma statt Punkt: `linuxmuster,net` → `linuxmuster.net`)
- `radius/index.rst`: `AP's` → `APs`, `udp` → `UDP`
- `use_linbo4/index.rst`: Variablenname `ECELEN` → `PIECELEN` (passend zum tatsächlichen Parameter in linuxmuster-linbo7) und Dateiname `linbi-torrent` → `linbo-torrent` (passend zur zwei Zeilen zuvor bereits korrekt genannten Datei)
- `exam-and-transfer.rst`: UI-Button-Text `Move _collect cirectory from all members` → `Move _collect directory from all members` (passend zum tatsächlichen Label in linuxmuster-webui7)

Nicht angefasst: `<hostename>` in `installation/proxmox/index.rst` — dort als konsistenter Platzhalter-Token über die gesamte Datei hinweg verwendet (keine Einzelfall-Tippfehler), daher unverändert gelassen.

## Test plan
- [ ] Sphinx build zur Kontrolle, dass keine neuen Warnungen entstehen