### PR TITLE
Migration guide: add missing steps and clarifications for v7.3 -> v7.4 upgrade

### DIFF
--- a/source/migration/upgrade.rst
+++ b/source/migration/upgrade.rst
@@ -13,7 +13,7 @@ Upgrade v7.3 auf v7.4
 Ablauf
 ------
 
-1. Bringe zuerst den lmn7.3 Server auf den aktuellsten Paketstand.
+1. Bringe zuerst den lmn7.3 Server auf den aktuellsten Paketstand. **Dieser Schritt ist zwingend erforderlich:** Das für die folgenden Schritte benötigte Skript ``linuxmuster-release-upgrade`` wird erst ab ``linuxmuster-base7`` Version 7.3.37 ausgeliefert und existiert auf älteren 7.3-Ständen noch nicht.
 
 Führe dazu in der Konsole folgende Befehle aus:
 
@@ -22,9 +22,35 @@ Führe dazu in der Konsole folgende Befehle aus:
    sudo apt update
    sudo apt dist-upgrade
 
+.. attention::
+
+   Prüfe anschließend, ob ein Neustart erforderlich ist, und starte den Server in diesem Fall neu, bevor Du fortfährst:
+
+   .. code::
+
+      test -f /var/run/reboot-required && echo "Neustart erforderlich" && reboot
+
 2. Falls Du OPNsense |reg| als Firewall einsetzt, aktualisiere diese zunächst auf eine Version >= 26.1.
 
-3. Hast Du die OPNsense |reg| aktualisiert, werden Deine bisherigen Firewall-Regeln mitgenommen. Diese musst Du nun unbedingt auf das neue Format für Firewall-Regeln migrieren. Dies erfolgt wie hier beschrieben:   https://www.thomas-krenn.com/en/wiki/OPNsense_26.1_Firewall_Rule_Migration
+   .. note::
+
+      Dieser Sprung erfolgt je nach Ausgangsstand in mehreren Stufen (z. B. 25.1 -> 25.7 -> 26.1) mit jeweils einem Neustart dazwischen — der Hinweis auf die jeweils nächste Major-Version erscheint erst, wenn die aktuell laufende Serie ihr letztes Patchlevel erreicht hat. Prüfe daher nach jedem Zwischenschritt erneut auf verfügbare Updates, bis Version 26.1 erreicht ist.
+
+      Führst Du das Update über das Konsolenmenü durch (Punkt **12) Update from console**), wird ein Major-Upgrade nicht mit ``y``, sondern durch Eintippen der Zielversionsnummer (z. B. ``25.7`` bzw. ``26.1``) bestätigt — ``y`` aktualisiert nur innerhalb der aktuell laufenden Serie.
+
+3. Hast Du die OPNsense |reg| aktualisiert, werden Deine bisherigen Firewall-Regeln mitgenommen. Diese musst Du nun unbedingt auf das neue Format für Firewall-Regeln migrieren:
+
+   a) Öffne in der OPNsense-Weboberfläche den Menüpunkt **Firewall** (den obersten Eintrag im Menü — nicht *Firewall → Rules*). Der Unterpunkt **Migration** erscheint dort nur, solange noch Legacy-Regeln oder Legacy-Outbound-NAT-Regeln vorhanden sind.
+   b) Exportiere Deine bestehenden Regeln über **Export as CSV**.
+   c) Importiere die CSV-Datei über **Import CSV** in die neuen Regeln.
+   d) Klicke auf **Apply**, um die importierten Regeln zu übernehmen.
+   e) Entferne abschließend die alten Regeln über **Remove all legacy rules**.
+
+   .. attention::
+
+      Prüfe vor dem Entfernen der Legacy-Regeln unbedingt, dass die neuen Regeln den von Dir benötigten Zugriff (insbesondere SSH- bzw. Konsolenzugriff) weiterhin erlauben — sonst kannst Du Dich von der Firewall aussperren.
+
+   Eine ausführliche Beschreibung mit Screenshots findest Du hier: https://www.thomas-krenn.com/en/wiki/OPNsense_26.1_Firewall_Rule_Migration
 
 4. Führe das Upgrade auf die linuxmuster.net v7.4 - wie nachstehend beschrieben - durch.
 
@@ -51,7 +77,22 @@ Rufe das Skript wie folgt auf:
 
    Falls Du Dich via SSH auf dem Server anmeldest, stelle sicher, dass Du als user ``root`` eine tmux-Session startest, damit das Upgrade nicht die SSH-Verbindung unterbricht.
 
-Das Upgrade dauert eine ganze Zeit. Du erhältst zu Beginn auf der Konsole den Hinweis, dass Du vor dem Upgrade einen Snapshot Deiner VM anlegen solltest. Zum Start des Upgrades musst Du dann den in der Konsole angezeigten Text eingeben und dies mit ENTER bestätigen. Danach startet das Upgrade.
+Das Upgrade dauert eine ganze Zeit. Du erhältst zu Beginn auf der Konsole den Hinweis, dass Du vor dem Upgrade einen Snapshot Deiner VM anlegen solltest. Zum Start des Upgrades musst Du ``YES`` eingeben und dies mit ENTER bestätigen.
+
+Anschließend versucht das Skript, die Grub-Boot-Disk automatisch zu erkennen, und fragt danach zur Bestätigung:
+
+.. code::
+
+   ## Trying to auto-detect all grub boot disks: /dev/vda
+   Input the grub boot disk to continue:
+
+Übernimm hier in der Regel den vom Skript direkt darüber angezeigten, automatisch erkannten Wert (bei virtualisierten Servern z. B. ``/dev/vda``, bei anderer Hardware/Hypervisoren ggf. ``/dev/sda`` oder ``/dev/nvme0n1``). Prüfe im Zweifel vorher mit ``lsblk``, welches Gerät die Root-Partition ``/`` enthält.
+
+.. note::
+
+   Bis zur Veröffentlichung von Ubuntu 26.04.1 (voraussichtlich 06.08.2026) meldet das Skript an dieser Stelle zusätzlich ``Upgrade to 26.04 is available as development release!`` und wechselt automatisch in den Devel-Modus. Das ist in diesem Zeitraum erwartet und kein Fehler.
+
+Danach startet das eigentliche Upgrade.
 
 Prüfe während des Upgrades, ob Fehler ausgegeben werden. Im Nachgang kannst Du zudem in der mitgeschriebenen Log-Datei ggf. nach Fehlern suchen.
 

--- a/source/migration/upgrade.rst
+++ b/source/migration/upgrade.rst
@@ -52,7 +52,7 @@ Führe dazu in der Konsole folgende Befehle aus:
 
    Eine ausführliche Beschreibung mit Screenshots findest Du hier: https://www.thomas-krenn.com/en/wiki/OPNsense_26.1_Firewall_Rule_Migration
 
-4. Führe das Upgrade auf die linuxmuster.net v7.4 - wie nachstehend beschrieben - durch.
+4. Führe das Upgrade auf die linuxmuster.net v7.4 - wie nachstehend beschrieben - durch. Setzt Du zusätzlich einen separaten Fileserver ein, aktualisiere diesen im Anschluss ebenfalls, siehe c) Fileserver aktualisieren.
 
 Upgrade
 -------
@@ -124,6 +124,23 @@ Prüfe nun, ob alle Dienste korrekt gestartet wurden.
    
 Du siehst ggf. einen Hinweis auf `quotaon.service`, der sich allerdings nur auf die Root-Partition bezieht, für die keine Quota gesetzt werden kann. Dies entspricht dem erwarteten Verhalten.
 
+**c) Fileserver aktualisieren**
+
+Setzt Du einen separaten Fileserver ein, bringst Du diesen anschließend ebenfalls auf Ubuntu 26.04 LTS. Anders als beim Server gibt es dafür kein eigenes linuxmuster.net-Skript — führe stattdessen ein reguläres Ubuntu-Release-Upgrade durch:
+
+.. code::
+
+   sudo apt update
+   sudo apt dist-upgrade
+   sudo do-release-upgrade
+
+.. note::
+
+   Bis zur Veröffentlichung von Ubuntu 26.04.1 (voraussichtlich 06.08.2026) musst Du dafür ggf. den Parameter ``-d`` ergänzen (``sudo do-release-upgrade -d``), da 26.04 bis dahin nur als Entwicklungsversion angeboten wird.
+
+Nach dem Upgrade ist der Fileserver auf demselben Samba-Stand wie der Server; ein separates ``linuxmuster-fileserver``-Paket für v7.4 wird dafür nicht benötigt.
+
+Starte den Fileserver anschließend neu und prüfe die Dienste wie unter b) beschrieben.
 
 
 


### PR DESCRIPTION
## Summary
Found while running the v7.3 -> v7.4 migration guide end-to-end on a fresh test environment. Several steps were either missing or ambiguous enough to cause confusion/hangs during the test:

- Step 1 (`apt dist-upgrade`) is not just hygiene — `linuxmuster-release-upgrade` only ships starting with `linuxmuster-base7` 7.3.37, so this step is a hard prerequisite. Now stated explicitly.
- Added a reboot check between the `dist-upgrade` and the release upgrade (a pending kernel/dbus update otherwise carries over silently).
- Documented the grub boot disk prompt (`Input the grub boot disk to continue:`) that `linuxmuster-release-upgrade` asks, including the auto-detected value the script prints right above it.
- Documented the `Upgrade to 26.04 is available as development release!` message that appears while Ubuntu 26.04 hasn't reached its first point release yet.
- Clarified that the OPNsense `>= 26.1` upgrade is a multi-step chain (e.g. 25.1 -> 25.7 -> 26.1) rather than a single update, since the hint for the next major version only appears once the running series is on its last patch level. Also documented that major upgrades via the console menu are confirmed by typing the target version number, not `y`.
- Replaced the firewall rule migration step (previously only an external wiki link) with the correct in-app steps: the migration assistant lives under the top-level **Firewall** menu entry (not *Firewall -> Rules* as the external doc suggests), and only appears while legacy rules/NAT exist. Added the 5 steps plus an anti-lockout warning; the external link is kept as further reading.

## Test plan
- [x] Built the changed page locally with `sphinx-build` (`de` locale) — builds cleanly, no new warnings.
- [x] All steps were verified against a real v7.3 -> v7.4 migration run on a test environment (server + OPNsense firewall).