### PR TITLE
Fix broken toctree entries in index.rst breaking RTD build

### DIFF
--- a/source/index.rst
+++ b/source/index.rst
@@ -110,8 +110,6 @@ Nach einem Klick auf die Leiste eröffnen sich Dir dort noch weitere Möglichkei
   :hidden:
 
   migration/index
-  migration/upgrade
-  migration/linbo-migration
 
 .. toctree::
   :maxdepth: 4


### PR DESCRIPTION
## Zusammenfassung
- `source/index.rst` enthielt einen Verweis auf `migration/linbo-migration`, die Datei existiert nicht mehr (früher `linbo-migration-to-4`, irgendwann entfernt, Referenz aber stehen gelassen)
- `migration/upgrade` war zusätzlich doppelt im Toctree gelistet

Der dangling reference erzeugt eine Sphinx-Warnung, die durch `fail_on_warning: true` in `.readthedocs.yml` den RTD-Build zum Scheitern bringt (siehe Build #33733422 u.a.). Bezieht sich auf die Diskussion in #1024.

## Test plan
- [x] Lokal mit dem exakten RTD-Build-Kommando geprüft: `sphinx-build -T -W --keep-going -b html -D language=de source _build` läuft ohne Warnungen/Fehler durch