### PR TITLE
Add data-protection notes to external LDAP service docs

### DIFF
--- a/source/external-services/_datenschutz-loeschung.rst
+++ b/source/external-services/_datenschutz-loeschung.rst
@@ -1,0 +1,14 @@
+.. attention::
+
+   **Datenschutz: Löschung von Benutzerdaten in extern angebundenen Diensten**
+
+   Wird ein/e Benutzer/in im AD der linuxmuster.net gelöscht, wirkt sich das nicht automatisch auf bereits dort
+   gespeicherte Daten in extern angebundenen Diensten aus. Je nach Konfiguration des jeweiligen Dienstes werden
+   entfernte Benutzer/innen beim nächsten LDAP-Sync ggf. nur gesperrt oder deaktiviert, ihre personenbezogenen
+   Daten (Kursinhalte, Dateien, Nachrichten etc.) bleiben aber bestehen.
+
+   Aus datenschutzrechtlicher Sicht (Löschpflicht, Speicherbegrenzung) müssen Administrator/innen sicherstellen,
+   dass personenbezogene Daten gelöschter Benutzer/innen auch in den angebundenen externen Diensten zeitnah
+   entfernt werden. Unterstützt der angebundene Dienst keine automatische Löschung (sondern nur eine
+   Sperrung/Deaktivierung) gelöschter LDAP-Benutzer/innen, so müssen diese Konten samt ihrer Daten
+   **regelmäßig manuell** im jeweiligen Dienst gelöscht werden, um den Datenschutzanforderungen zu genügen.

--- a/source/external-services/_ldap-vertrauen-keycloak.rst
+++ b/source/external-services/_ldap-vertrauen-keycloak.rst
@@ -1,0 +1,13 @@
+.. attention::
+
+   **Vertrauen bei direkter LDAP-Anbindung**
+
+   Bei einer direkten LDAP-Anbindung gibt der Bind-User zwar keine Nutzerpasswörter preis, wohl aber geben die
+   Nutzer/innen selbst ihr AD-Passwort direkt auf der Weboberfläche des externen Dienstes ein. Diesem Dienst
+   (bzw. dessen Betreiber) muss man also entsprechend vertrauen, da er potenziell an die eingegebenen
+   Zugangsdaten gelangen könnte.
+
+   Steht stattdessen ein Keycloak zur Verfügung (z.B. bei Edulution bereits integriert, oder selbst betrieben
+   und an die linuxmuster.net angebunden), ist es aus Datenschutz-/Sicherheitssicht vorzuziehen, Dienste über
+   Keycloak per SSO (OIDC/SAML) statt per direktem LDAP-Bind anzubinden: Die Passwörter/Secrets der Nutzer/innen
+   verbleiben dann stets auf der eigenen Infrastruktur und werden dem externen Dienst nie direkt mitgeteilt.

--- a/source/external-services/aleksis/index.rst
+++ b/source/external-services/aleksis/index.rst
@@ -68,9 +68,10 @@ Sind die benötigten LDAP Pakete installiert muss die LDAP Konfiguration in der 
 
 Die ``uri`` muss natürlich auf die jeweilige Schule mit dem entsprechenden Domain Namen angepasst werden ebenso bei ``search``
 
-Sollte die Aleksis Instanz extern betrtrieben werden. Ist es dringend empfohlen den Port ``636`` für LDAPs zu verwenden außerdem bei ``uri`` 
-statt ``ldap:`` ebenfalls ``ldaps`` einzutragen. 
+Sollte die Aleksis Instanz extern betrtrieben werden. Ist es dringend empfohlen den Port ``636`` für LDAPs zu verwenden außerdem bei ``uri``
+statt ``ldap:`` ebenfalls ``ldaps`` einzutragen.
 
+.. include:: /external-services/_ldap-vertrauen-keycloak.rst
 
 Als nächstes wechselt man in die Aleksis Weboberfläche und wechselt auf der linken Seite auf ``Admin`` und dann auf ``LDAP``
 
@@ -107,3 +108,5 @@ Alle anderen Felder sollten leer bleiben
 Am Ende die Einstellungen mit ``EINSTELLUNGEN SPEICHERN`` bestätigen.
 
 Jetzt sollte der Benutzer in der Lage sein sich anzumelden. Die LDAP Anbindung ist hiermit abgeschlossen.
+
+.. include:: /external-services/_datenschutz-loeschung.rst

--- a/source/external-services/moodle/index.rst
+++ b/source/external-services/moodle/index.rst
@@ -70,7 +70,9 @@ Bind-Einstellungen
 
 .. attention::
 
-   Grundsätzlich sollten alle externen Dienste, die via LDAP an das AD angebunden werden, mit einem eigens dafür angelegten Bind-User genutzt werden. Für Moodle sollte so z.B. ein Benutzer ``moodle-binduser`` angelegt werden, der für die Verbindung zum AD genutzt wird. Hinweise hierzu findest Du unter https://github.com/linuxmuster/sophomorix4/wiki/bindusers 
+   Grundsätzlich sollten alle externen Dienste, die via LDAP an das AD angebunden werden, mit einem eigens dafür angelegten Bind-User genutzt werden. Für Moodle sollte so z.B. ein Benutzer ``moodle-binduser`` angelegt werden, der für die Verbindung zum AD genutzt wird. Hinweise hierzu findest Du unter https://github.com/linuxmuster/sophomorix4/wiki/bindusers
+
+.. include:: /external-services/_ldap-vertrauen-keycloak.rst
 
 **Vorgehen zur Anlage eines neuen Bind-Users**
 
@@ -165,6 +167,8 @@ Weitere Einstellungen
 +-------------------------------------------------+-----------------------------------------------+
 | Status von lokalen Nutzerkonten synchronisieren | Nein                                          |
 +-------------------------------------------------+-----------------------------------------------+
+
+.. include:: /external-services/_datenschutz-loeschung.rst
 
 **NTLM-SSO**
 

--- a/source/external-services/nextcloud/authentication.rst
+++ b/source/external-services/nextcloud/authentication.rst
@@ -43,7 +43,9 @@ Bind-User
 
 .. attention::
 
-   Grundsätzlich sollten alle externen Dienste, die via LDAP an das AD angebunden werden, mit einem eigens dafür angelegten Bind-User genutzt werden. Für Nextcloud sollte so z.B. ein Benutzer ``nextcloud-binduser`` angelegt werden, der für die Verbindung zum AD genutzt wird. Hinweise hierzu findest Du unter https://github.com/linuxmuster/sophomorix4/wiki/bindusers 
+   Grundsätzlich sollten alle externen Dienste, die via LDAP an das AD angebunden werden, mit einem eigens dafür angelegten Bind-User genutzt werden. Für Nextcloud sollte so z.B. ein Benutzer ``nextcloud-binduser`` angelegt werden, der für die Verbindung zum AD genutzt wird. Hinweise hierzu findest Du unter https://github.com/linuxmuster/sophomorix4/wiki/bindusers
+
+.. include:: /external-services/_ldap-vertrauen-keycloak.rst
 
 **Vorgehen zur Anlage eines neuen Bind-Users**
 
@@ -197,4 +199,6 @@ Im Feld ``Standard-Kontingent`` wird festgelegt, wie viel Speicher dem Benutzer 
 Das ``"$home"Platzhalter-Feld`` brauchst Du, wenn Du die Home-Verzeichnisse auch in der Nextcloud zur Verfügung stellen möchtest.
 
 So, das war's. Sicherheitshalber gehst Du nochmal auf den Reiter ``Experte`` und klicks auf  ``Lösche LDAP-Benutzernamenzuordung`` und ``Lösche LDAP-Gruppennamenzuordung``.
+
+.. include:: /external-services/_datenschutz-loeschung.rst
 


### PR DESCRIPTION
## Summary
- Add a reusable note explaining that deleting an lmn user does not automatically delete their data in externally connected services (Moodle, Nextcloud, AlekSIS) — depending on the service's sync config, the account may only be locked/disabled, so leftover personal data may need manual deletion to comply with data protection requirements.
- Add a second reusable note next to the bind-user sections pointing out that direct LDAP bind means users enter their AD password on the external service's own web UI, requiring trust in that provider — and that SSO via Keycloak (e.g. bundled with Edulution, or self-hosted and coupled to lmn) is preferable where available, since credentials then stay on local infrastructure.
- Both notes are added as standalone `.rst` snippets under `source/external-services/` and included via `.. include::` in `moodle/index.rst`, `nextcloud/authentication.rst`, and `aleksis/index.rst`, so the text stays centrally maintainable.

Closes #376

## Test plan
- [x] `sphinx-build` of the three edited pages (moodle, nextcloud authentication, aleksis) completes with no new warnings/errors beyond the pre-existing, unrelated toctree warning for `migration/linbo-migration` in `source/index.rst` (present on `v7.4` before this change).