### PR TITLE
Link migration overview to detailed upgrade guide (#1030)

### DIFF
--- a/source/migration/index.rst
+++ b/source/migration/index.rst
@@ -18,3 +18,5 @@ Um auf die linuxmuster 7.4 zu migrieren:
 4. Führe danach das ``linuxmuster-release-upgrade`` durch. Falls erforderlich führe nach dem Upgrade einen Neustart der Server durch.
 5. Falls Du den File-Server installiert hast, führe für diesen ein release-upgrade auf Ubuntu 26.04 LTS durch.
 
+Eine ausführliche Schritt-für-Schritt-Anleitung zu diesen Punkten findest Du unter :ref:`Upgrade v7.3 auf v7.4 <upgrade-from-7.3-label>`.
+


### PR DESCRIPTION
## Summary
- `source/migration/index.rst` (Übersicht) listed the migration steps but had no cross-reference to `source/migration/upgrade.rst`, which contains the actual step-by-step instructions (sudo usage, fileserver upgrade, OPNsense rule migration, etc. from #1024/#1025).
- Adds a `:ref:` link to `upgrade-from-7.3-label` at the end of the overview page so readers entering via `migration/index.html` can find the detailed guide.

Fixes #1030.